### PR TITLE
Adds 'head' option to allow user get the first specific number of ion values of the input file.

### DIFF
--- a/src/bin/ion/commands/beta/head.rs
+++ b/src/bin/ion/commands/beta/head.rs
@@ -1,0 +1,48 @@
+use crate::commands::dump;
+use anyhow::Result;
+use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
+
+pub fn app() -> Command {
+    Command::new("head")
+        .about("Prints the specified number of top-level values in the input stream.")
+        .arg(
+            Arg::new("values")
+                .long("values")
+                .short('n')
+                .value_parser(value_parser!(usize))
+                .allow_negative_numbers(false)
+                .default_value("10")
+                .help("Specifies the number of output top-level values."),
+        )
+        .arg(
+            Arg::new("format")
+                .long("format")
+                .short('f')
+                .default_value("lines")
+                .value_parser(["binary", "text", "pretty", "lines"])
+                .help("Output format"),
+        )
+        .arg(
+            Arg::new("output")
+                .long("output")
+                .short('o')
+                .help("Output file [default: STDOUT]"),
+        )
+        .arg(
+            // All argv entries after the program name (argv[0])
+            // and any `clap`-managed options are considered input files.
+            Arg::new("input")
+                .index(1)
+                .help("Input file [default: STDIN]")
+                .action(ArgAction::Append)
+                .trailing_var_arg(true),
+        )
+}
+
+pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
+    //TODO: Extract common value-handling logic for both `head` and `dump`
+    // https://github.com/amazon-ion/ion-cli/issues/49
+    //TODO: Multiple file handling in classic `head` includes a header per file.
+    // https://github.com/amazon-ion/ion-cli/issues/48
+    dump::run(_command_name, matches)
+}

--- a/src/bin/ion/commands/beta/mod.rs
+++ b/src/bin/ion/commands/beta/mod.rs
@@ -1,5 +1,6 @@
 pub mod count;
 pub mod from;
+pub mod head;
 pub mod inspect;
 pub mod primitive;
 pub mod schema;
@@ -19,6 +20,7 @@ pub fn beta_subcommands() -> Vec<Command> {
         inspect::app(),
         primitive::app(),
         schema::app(),
+        head::app(),
         from::app(),
         to::app(),
     ]
@@ -32,6 +34,7 @@ pub fn runner_for_beta_subcommand(command_name: &str) -> Option<CommandRunner> {
         "schema" => schema::run,
         "from" => from::run,
         "to" => to::run,
+        "head" => head::run,
         _ => return None,
     };
     Some(runner)

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use clap::{ArgMatches, Command};
-
 pub mod beta;
 pub mod dump;
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -144,3 +144,48 @@ fn run_it<S: AsRef<str>>(
 
     Ok(())
 }
+
+#[rstest]
+#[case(0, "")]
+#[case(2, "{foo: bar, abc: [123, 456]}\n{foo: baz, abc: [420d-1, 4.3e1]}")]
+///Calls ion-cli beta head with different requested number. Pass the test if the return value equals to the expected value.
+fn test_write_all_values(#[case] number: i32, #[case] expected_output: &str) -> Result<()> {
+    let mut cmd = Command::cargo_bin("ion")?;
+    let test_data = r#"
+    {
+        foo: bar,
+        abc: [123, 456]
+    }
+    {
+        foo: baz,
+        abc: [42.0, 43e0]
+    }
+    {
+        foo: bar,
+        test: data
+    }
+    {
+        foo: baz,
+        type: struct
+    }
+    "#;
+    let temp_dir = TempDir::new()?;
+    let input_path = temp_dir.path().join("test.ion");
+    let mut input_file = File::create(&input_path)?;
+    input_file.write(test_data.as_bytes())?;
+    input_file.flush()?;
+    cmd.args(&[
+        "beta",
+        "head",
+        "--values",
+        &number.to_string(),
+        "--format",
+        "lines",
+        input_path.to_str().unwrap(),
+    ]);
+    let command_assert = cmd.assert();
+    let output = command_assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim_end(), expected_output);
+    Ok(())
+}


### PR DESCRIPTION
### Issue #, if available:
N/A
### Description of changes:

This PR adds an option `head` to `ion-cli` tool, which allows to get the first specific number of top-level data in the input stream.
Here is the example of print out the fist 2 top-level value of testData.ion:

`ion beta head --number 2 --format lines testData.ion`

Results:
```
{foo: bar, abc: [123, 456]}
{foo: baz, abc: [420d-1, 4.3e1]} 
```

Original data testData.ion:

```
{
    foo: bar,
    abc: [123, 456]
}
{
    foo: baz,
    abc: [42.0, 43e0]
}
{
    foo: bar,
    test: data
}
{
    foo: baz,
    type: struct
}
```
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
