### PR TITLE
Upgrades ion-rs to v0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,7 @@ dependencies = [
  "base64 0.21.2",
  "clap",
  "colored",
- "ion-rs 0.18.0",
+ "ion-rs 0.18.1",
  "ion-schema",
  "memmap",
  "rstest",
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "ion-rs"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27af4be256e55b7bb11dcceb727a1c754f4f74653781489ed7c4901d3bee5d6e"
+checksum = "7434986c985887a9da57b80429e02225cc561d0a9351fcd39aa309f08abea7db"
 dependencies = [
  "arrayvec",
  "base64 0.12.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["format", "parse", "encode"]
 anyhow = "1.0"
 clap = { version = "4.0.17", features = ["cargo"] }
 colored = "2.0.0"
-ion-rs = "0.18.0"
+ion-rs = "0.18.1"
 memmap = "0.7.0"
 tempfile = "3.2.0"
 ion-schema = "0.7.0"


### PR DESCRIPTION
`ion-rs` v0.18.0 had a bug in the raw bytes accessors for the `SystemReader` that caused it to panic after reading more than ~4KB of data. [v0.18.1](https://github.com/amazon-ion/ion-rust/pull/566) addressed that problem.

This PR upgrades our dependency on `ion-rs` to v0.18.1, allowing the `inspect` command to use the latest `ion-rs`.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
