### PR TITLE
Command traits

### DIFF
--- a/src/bin/ion/commands/beta/count.rs
+++ b/src/bin/ion/commands/beta/count.rs
@@ -1,4 +1,4 @@
-use crate::IonCliCommand;
+use crate::commands::IonCliCommand;
 use anyhow::{Context, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use ion_rs::*;

--- a/src/bin/ion/commands/beta/count.rs
+++ b/src/bin/ion/commands/beta/count.rs
@@ -3,37 +3,50 @@ use clap::{Arg, ArgAction, ArgMatches, Command};
 use ion_rs::*;
 use std::fs::File;
 use std::io::{stdin, BufReader, StdinLock};
+use crate::IonCliCommand;
 
-pub fn app() -> Command {
-    Command::new("count")
-        .about("Prints the number of top-level values found in the input stream.")
-        .arg(
-            // All argv entries after the program name (argv[0])
-            // and any `clap`-managed options are considered input files.
-            Arg::new("input")
-                .index(1)
-                .help("Input file [default: STDIN]")
-                .action(ArgAction::Append)
-                .trailing_var_arg(true),
-        )
-}
+pub struct CountCommand;
 
-pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
-    if let Some(input_file_iter) = matches.get_many::<String>("input") {
-        for input_file in input_file_iter {
-            let file = File::open(input_file)
-                .with_context(|| format!("Could not open file '{}'", input_file))?;
-            let mut reader = ReaderBuilder::new().build(file)?;
+impl IonCliCommand for CountCommand {
+    fn name(&self) -> &'static str {
+        "count"
+    }
+
+    fn about(&self) -> &'static str {
+        "Prints the number of top-level values found in the input stream."
+    }
+
+    fn clap_command(&self) -> Command {
+        Command::new(self.name())
+            .about(self.about())
+            .arg(
+                // All argv entries after the program name (argv[0])
+                // and any `clap`-managed options are considered input files.
+                Arg::new("input")
+                    .index(1)
+                    .help("Input file [default: STDIN]")
+                    .action(ArgAction::Append)
+                    .trailing_var_arg(true),
+            )
+    }
+
+    fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
+        if let Some(input_file_iter) = args.get_many::<String>("input") {
+            for input_file in input_file_iter {
+                let file = File::open(input_file)
+                    .with_context(|| format!("Could not open file '{}'", input_file))?;
+                let mut reader = ReaderBuilder::new().build(file)?;
+                print_top_level_value_count(&mut reader)?;
+            }
+        } else {
+            let input: StdinLock = stdin().lock();
+            let buf_reader = BufReader::new(input);
+            let mut reader = ReaderBuilder::new().build(buf_reader)?;
             print_top_level_value_count(&mut reader)?;
-        }
-    } else {
-        let input: StdinLock = stdin().lock();
-        let buf_reader = BufReader::new(input);
-        let mut reader = ReaderBuilder::new().build(buf_reader)?;
-        print_top_level_value_count(&mut reader)?;
-    };
+        };
 
-    Ok(())
+        Ok(())
+    }
 }
 
 fn print_top_level_value_count(reader: &mut Reader) -> Result<()> {

--- a/src/bin/ion/commands/beta/count.rs
+++ b/src/bin/ion/commands/beta/count.rs
@@ -1,9 +1,9 @@
+use crate::IonCliCommand;
 use anyhow::{Context, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use ion_rs::*;
 use std::fs::File;
 use std::io::{stdin, BufReader, StdinLock};
-use crate::IonCliCommand;
 
 pub struct CountCommand;
 
@@ -17,17 +17,15 @@ impl IonCliCommand for CountCommand {
     }
 
     fn clap_command(&self) -> Command {
-        Command::new(self.name())
-            .about(self.about())
-            .arg(
-                // All argv entries after the program name (argv[0])
-                // and any `clap`-managed options are considered input files.
-                Arg::new("input")
-                    .index(1)
-                    .help("Input file [default: STDIN]")
-                    .action(ArgAction::Append)
-                    .trailing_var_arg(true),
-            )
+        Command::new(self.name()).about(self.about()).arg(
+            // All argv entries after the program name (argv[0])
+            // and any `clap`-managed options are considered input files.
+            Arg::new("input")
+                .index(1)
+                .help("Input file [default: STDIN]")
+                .action(ArgAction::Append)
+                .trailing_var_arg(true),
+        )
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {

--- a/src/bin/ion/commands/beta/count.rs
+++ b/src/bin/ion/commands/beta/count.rs
@@ -1,6 +1,6 @@
-use crate::commands::IonCliCommand;
+use crate::commands::{IonCliCommand, WithIonCliArgument};
 use anyhow::{Context, Result};
-use clap::{Arg, ArgAction, ArgMatches, Command};
+use clap::{ArgMatches, Command};
 use ion_rs::*;
 use std::fs::File;
 use std::io::{stdin, BufReader, StdinLock};
@@ -16,16 +16,8 @@ impl IonCliCommand for CountCommand {
         "Prints the number of top-level values found in the input stream."
     }
 
-    fn clap_command(&self) -> Command {
-        Command::new(self.name()).about(self.about()).arg(
-            // All argv entries after the program name (argv[0])
-            // and any `clap`-managed options are considered input files.
-            Arg::new("input")
-                .index(1)
-                .help("Input file [default: STDIN]")
-                .action(ArgAction::Append)
-                .trailing_var_arg(true),
-        )
+    fn configure_args(&self, command: Command) -> Command {
+        command.with_input()
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {

--- a/src/bin/ion/commands/beta/from/json.rs
+++ b/src/bin/ion/commands/beta/from/json.rs
@@ -1,7 +1,7 @@
 use crate::commands::dump;
+use crate::IonCliCommand;
 use anyhow::Result;
 use clap::{Arg, ArgAction, ArgMatches, Command};
-use crate::IonCliCommand;
 
 pub struct FromJsonCommand;
 

--- a/src/bin/ion/commands/beta/from/json.rs
+++ b/src/bin/ion/commands/beta/from/json.rs
@@ -1,5 +1,5 @@
 use crate::commands::dump;
-use crate::IonCliCommand;
+use crate::commands::IonCliCommand;
 use anyhow::Result;
 use clap::{Arg, ArgAction, ArgMatches, Command};
 

--- a/src/bin/ion/commands/beta/from/json.rs
+++ b/src/bin/ion/commands/beta/from/json.rs
@@ -1,7 +1,6 @@
-use crate::commands::dump;
-use crate::commands::IonCliCommand;
+use crate::commands::{dump, IonCliCommand, WithIonCliArgument};
 use anyhow::Result;
-use clap::{Arg, ArgAction, ArgMatches, Command};
+use clap::{ArgMatches, Command};
 
 pub struct FromJsonCommand;
 
@@ -14,32 +13,8 @@ impl IonCliCommand for FromJsonCommand {
         "Converts data from JSON to Ion."
     }
 
-    fn clap_command(&self) -> Command {
-        Command::new(self.name())
-            .about(self.about())
-            .arg(
-                Arg::new("output")
-                    .long("output")
-                    .short('o')
-                    .help("Output file [default: STDOUT]"),
-            )
-            .arg(
-                Arg::new("format")
-                    .long("format")
-                    .short('f')
-                    .default_value("pretty")
-                    .value_parser(["binary", "text", "pretty", "lines"])
-                    .help("Output format"),
-            )
-            .arg(
-                // Any number of input files can be specified by repeating the "-i" or "--input" flags.
-                // Unlabeled positional arguments will also be considered input file names.
-                Arg::new("input")
-                    .index(1)
-                    .trailing_var_arg(true)
-                    .action(ArgAction::Append)
-                    .help("Input file"),
-            )
+    fn configure_args(&self, command: Command) -> Command {
+        command.with_input().with_output().with_format()
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {

--- a/src/bin/ion/commands/beta/from/json.rs
+++ b/src/bin/ion/commands/beta/from/json.rs
@@ -1,42 +1,50 @@
 use crate::commands::dump;
 use anyhow::Result;
 use clap::{Arg, ArgAction, ArgMatches, Command};
+use crate::IonCliCommand;
 
-const ABOUT: &str = "Converts data from JSON to Ion.";
+pub struct FromJsonCommand;
 
-// Creates a `clap` (Command Line Arguments Parser) configuration for the `from` command.
-// This function is invoked by the parent command,`from`, so it can describe its child commands.
-pub fn app() -> Command {
-    Command::new("json")
-        .about(ABOUT)
-        .arg(
-            Arg::new("output")
-                .long("output")
-                .short('o')
-                .help("Output file [default: STDOUT]"),
-        )
-        .arg(
-            Arg::new("format")
-                .long("format")
-                .short('f')
-                .default_value("pretty")
-                .value_parser(["binary", "text", "pretty", "lines"])
-                .help("Output format"),
-        )
-        .arg(
-            // Any number of input files can be specified by repeating the "-i" or "--input" flags.
-            // Unlabeled positional arguments will also be considered input file names.
-            Arg::new("input")
-                .index(1)
-                .trailing_var_arg(true)
-                .action(ArgAction::Append)
-                .help("Input file"),
-        )
-}
+impl IonCliCommand for FromJsonCommand {
+    fn name(&self) -> &'static str {
+        "json"
+    }
 
-// This function is invoked by the `from` command's parent, `beta`.
-pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
-    // Because JSON data is valid Ion, the `dump` command may be reused for converting JSON.
-    // TODO ideally, this would perform some smarter "up-conversion".
-    dump::run("json", matches)
+    fn about(&self) -> &'static str {
+        "Converts data from JSON to Ion."
+    }
+
+    fn clap_command(&self) -> Command {
+        Command::new(self.name())
+            .about(self.about())
+            .arg(
+                Arg::new("output")
+                    .long("output")
+                    .short('o')
+                    .help("Output file [default: STDOUT]"),
+            )
+            .arg(
+                Arg::new("format")
+                    .long("format")
+                    .short('f')
+                    .default_value("pretty")
+                    .value_parser(["binary", "text", "pretty", "lines"])
+                    .help("Output format"),
+            )
+            .arg(
+                // Any number of input files can be specified by repeating the "-i" or "--input" flags.
+                // Unlabeled positional arguments will also be considered input file names.
+                Arg::new("input")
+                    .index(1)
+                    .trailing_var_arg(true)
+                    .action(ArgAction::Append)
+                    .help("Input file"),
+            )
+    }
+
+    fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
+        // Because JSON data is valid Ion, the `dump` command may be reused for converting JSON.
+        // TODO ideally, this would perform some smarter "up-conversion".
+        dump::run("json", args)
+    }
 }

--- a/src/bin/ion/commands/beta/from/mod.rs
+++ b/src/bin/ion/commands/beta/from/mod.rs
@@ -12,7 +12,7 @@ impl IonCliCommand for FromNamespace {
     }
 
     fn about(&self) -> &'static str {
-        "'from' is a namespace for commands that converts other data formats to Ion."
+        "'from' is a namespace for commands that convert other data formats to Ion."
     }
 
     fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {

--- a/src/bin/ion/commands/beta/from/mod.rs
+++ b/src/bin/ion/commands/beta/from/mod.rs
@@ -1,4 +1,4 @@
-use crate::IonCliCommand;
+use crate::commands::IonCliCommand;
 
 use crate::commands::beta::from::json::FromJsonCommand;
 

--- a/src/bin/ion/commands/beta/from/mod.rs
+++ b/src/bin/ion/commands/beta/from/mod.rs
@@ -1,42 +1,22 @@
-use crate::commands::CommandRunner;
-use anyhow::Result;
-use clap::{ArgMatches, Command};
+use crate::{IonCliCommand};
+
+
+use crate::commands::beta::from::json::FromJsonCommand;
 
 pub mod json;
 
-// Creates a Vec of CLI configurations for all of the available built-in commands
-pub fn subcommands() -> Vec<Command> {
-    vec![json::app()]
-}
+pub struct FromNamespace;
 
-// Maps the given command name to the entry point for that command if it exists
-pub fn runner_for_from_command(command_name: &str) -> Option<CommandRunner> {
-    let runner = match command_name {
-        "json" => json::run,
-        _ => return None,
-    };
-    Some(runner)
-}
-
-// The functions below are used by the parent `beta` command when `to` is invoked.
-pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
-    //     ^-- At this level of dispatch, this command will always be the text `to`.
-    // We want to evaluate the name of the subcommand that was invoked --v
-    let (command_name, command_args) = matches.subcommand().unwrap();
-    if let Some(runner) = runner_for_from_command(command_name) {
-        runner(command_name, command_args)?;
-    } else {
-        let message = format!(
-            "The requested `from` command ('{}') is not supported and clap did not generate an error message.",
-            command_name
-        );
-        unreachable!("{}", message);
+impl IonCliCommand for FromNamespace {
+    fn name(&self) -> &'static str {
+        "from"
     }
-    Ok(())
-}
 
-pub fn app() -> Command {
-    Command::new("from")
-        .about("'from' is a namespace for commands that converts other data formats to Ion.")
-        .subcommands(subcommands())
+    fn about(&self) -> &'static str {
+        "'from' is a namespace for commands that converts other data formats to Ion."
+    }
+
+    fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {
+        vec![Box::new(FromJsonCommand)]
+    }
 }

--- a/src/bin/ion/commands/beta/from/mod.rs
+++ b/src/bin/ion/commands/beta/from/mod.rs
@@ -1,5 +1,4 @@
-use crate::{IonCliCommand};
-
+use crate::IonCliCommand;
 
 use crate::commands::beta::from::json::FromJsonCommand;
 

--- a/src/bin/ion/commands/beta/head.rs
+++ b/src/bin/ion/commands/beta/head.rs
@@ -1,7 +1,7 @@
 use crate::commands::dump;
+use crate::IonCliCommand;
 use anyhow::Result;
 use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
-use crate::IonCliCommand;
 
 pub struct HeadCommand;
 
@@ -59,4 +59,3 @@ impl IonCliCommand for HeadCommand {
         dump::run(command_path.last().unwrap(), args)
     }
 }
-

--- a/src/bin/ion/commands/beta/head.rs
+++ b/src/bin/ion/commands/beta/head.rs
@@ -1,48 +1,62 @@
 use crate::commands::dump;
 use anyhow::Result;
 use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
+use crate::IonCliCommand;
 
-pub fn app() -> Command {
-    Command::new("head")
-        .about("Prints the specified number of top-level values in the input stream.")
-        .arg(
-            Arg::new("values")
-                .long("values")
-                .short('n')
-                .value_parser(value_parser!(usize))
-                .allow_negative_numbers(false)
-                .default_value("10")
-                .help("Specifies the number of output top-level values."),
-        )
-        .arg(
-            Arg::new("format")
-                .long("format")
-                .short('f')
-                .default_value("lines")
-                .value_parser(["binary", "text", "pretty", "lines"])
-                .help("Output format"),
-        )
-        .arg(
-            Arg::new("output")
-                .long("output")
-                .short('o')
-                .help("Output file [default: STDOUT]"),
-        )
-        .arg(
-            // All argv entries after the program name (argv[0])
-            // and any `clap`-managed options are considered input files.
-            Arg::new("input")
-                .index(1)
-                .help("Input file [default: STDIN]")
-                .action(ArgAction::Append)
-                .trailing_var_arg(true),
-        )
+pub struct HeadCommand;
+
+impl IonCliCommand for HeadCommand {
+    fn name(&self) -> &'static str {
+        "head"
+    }
+
+    fn about(&self) -> &'static str {
+        "Prints the specified number of top-level values in the input stream."
+    }
+
+    fn clap_command(&self) -> Command {
+        Command::new(self.name())
+            .about(self.about())
+            .arg(
+                Arg::new("values")
+                    .long("values")
+                    .short('n')
+                    .value_parser(value_parser!(usize))
+                    .allow_negative_numbers(false)
+                    .default_value("10")
+                    .help("Specifies the number of output top-level values."),
+            )
+            .arg(
+                Arg::new("format")
+                    .long("format")
+                    .short('f')
+                    .default_value("lines")
+                    .value_parser(["binary", "text", "pretty", "lines"])
+                    .help("Output format"),
+            )
+            .arg(
+                Arg::new("output")
+                    .long("output")
+                    .short('o')
+                    .help("Output file [default: STDOUT]"),
+            )
+            .arg(
+                // All argv entries after the program name (argv[0])
+                // and any `clap`-managed options are considered input files.
+                Arg::new("input")
+                    .index(1)
+                    .help("Input file [default: STDIN]")
+                    .action(ArgAction::Append)
+                    .trailing_var_arg(true),
+            )
+    }
+
+    fn run(&self, command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
+        //TODO: Extract common value-handling logic for both `head` and `dump`
+        // https://github.com/amazon-ion/ion-cli/issues/49
+        //TODO: Multiple file handling in classic `head` includes a header per file.
+        // https://github.com/amazon-ion/ion-cli/issues/48
+        dump::run(command_path.last().unwrap(), args)
+    }
 }
 
-pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
-    //TODO: Extract common value-handling logic for both `head` and `dump`
-    // https://github.com/amazon-ion/ion-cli/issues/49
-    //TODO: Multiple file handling in classic `head` includes a header per file.
-    // https://github.com/amazon-ion/ion-cli/issues/48
-    dump::run(_command_name, matches)
-}

--- a/src/bin/ion/commands/beta/head.rs
+++ b/src/bin/ion/commands/beta/head.rs
@@ -1,7 +1,6 @@
-use crate::commands::dump;
-use crate::commands::IonCliCommand;
+use crate::commands::{dump, IonCliCommand, WithIonCliArgument};
 use anyhow::Result;
-use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
+use clap::{value_parser, Arg, ArgMatches, Command};
 
 pub struct HeadCommand;
 
@@ -14,41 +13,16 @@ impl IonCliCommand for HeadCommand {
         "Prints the specified number of top-level values in the input stream."
     }
 
-    fn clap_command(&self) -> Command {
-        Command::new(self.name())
-            .about(self.about())
-            .arg(
-                Arg::new("values")
-                    .long("values")
-                    .short('n')
-                    .value_parser(value_parser!(usize))
-                    .allow_negative_numbers(false)
-                    .default_value("10")
-                    .help("Specifies the number of output top-level values."),
-            )
-            .arg(
-                Arg::new("format")
-                    .long("format")
-                    .short('f')
-                    .default_value("lines")
-                    .value_parser(["binary", "text", "pretty", "lines"])
-                    .help("Output format"),
-            )
-            .arg(
-                Arg::new("output")
-                    .long("output")
-                    .short('o')
-                    .help("Output file [default: STDOUT]"),
-            )
-            .arg(
-                // All argv entries after the program name (argv[0])
-                // and any `clap`-managed options are considered input files.
-                Arg::new("input")
-                    .index(1)
-                    .help("Input file [default: STDIN]")
-                    .action(ArgAction::Append)
-                    .trailing_var_arg(true),
-            )
+    fn configure_args(&self, command: Command) -> Command {
+        command.with_input().with_output().with_format().arg(
+            Arg::new("values")
+                .long("values")
+                .short('n')
+                .value_parser(value_parser!(usize))
+                .allow_negative_numbers(false)
+                .default_value("10")
+                .help("Specifies the number of output top-level values."),
+        )
     }
 
     fn run(&self, command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {

--- a/src/bin/ion/commands/beta/head.rs
+++ b/src/bin/ion/commands/beta/head.rs
@@ -1,5 +1,5 @@
 use crate::commands::dump;
-use crate::IonCliCommand;
+use crate::commands::IonCliCommand;
 use anyhow::Result;
 use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 

--- a/src/bin/ion/commands/beta/inspect.rs
+++ b/src/bin/ion/commands/beta/inspect.rs
@@ -6,7 +6,7 @@ use std::io::BufWriter;
 use std::ops::Range;
 use std::str::{from_utf8_unchecked, FromStr};
 
-use crate::IonCliCommand;
+use crate::commands::IonCliCommand;
 use anyhow::{bail, Context, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use colored::Colorize;

--- a/src/bin/ion/commands/beta/inspect.rs
+++ b/src/bin/ion/commands/beta/inspect.rs
@@ -6,6 +6,7 @@ use std::io::BufWriter;
 use std::ops::Range;
 use std::str::{from_utf8_unchecked, FromStr};
 
+use crate::IonCliCommand;
 use anyhow::{bail, Context, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use colored::Colorize;
@@ -14,7 +15,6 @@ use ion_rs::element::writer::TextKind;
 use ion_rs::result::{decoding_error, IonResult};
 use ion_rs::*;
 use memmap::MmapOptions;
-use crate::IonCliCommand;
 
 pub struct InspectCommand;
 
@@ -100,8 +100,8 @@ complete value will be displayed.",
 
         // If the user has specified an output file, use it.
         let mut output: OutputRef = if let Some(file_name) = args.get_one::<String>("output") {
-            let output_file =
-                File::create(file_name).with_context(|| format!("Could not open '{}'", file_name))?;
+            let output_file = File::create(file_name)
+                .with_context(|| format!("Could not open '{}'", file_name))?;
             let buf_writer = BufWriter::new(output_file);
             Box::new(buf_writer)
         } else {
@@ -132,8 +132,8 @@ complete value will be displayed.",
             // Create a temporary file that will delete itself when the program ends.
             let mut input_file = tempfile::tempfile().with_context(|| {
                 concat!(
-                "Failed to create a temporary file to store STDIN.",
-                "Try passing an --input flag instead."
+                    "Failed to create a temporary file to store STDIN.",
+                    "Try passing an --input flag instead."
                 )
             })?;
 
@@ -157,8 +157,6 @@ complete value will be displayed.",
         Ok(())
     }
 }
-
-
 
 // Create a type alias to simplify working with a shared reference to our output stream.
 type OutputRef = Box<dyn io::Write>;

--- a/src/bin/ion/commands/beta/inspect.rs
+++ b/src/bin/ion/commands/beta/inspect.rs
@@ -6,9 +6,9 @@ use std::io::BufWriter;
 use std::ops::Range;
 use std::str::{from_utf8_unchecked, FromStr};
 
-use crate::commands::IonCliCommand;
+use crate::commands::{IonCliCommand, WithIonCliArgument};
 use anyhow::{bail, Context, Result};
-use clap::{Arg, ArgAction, ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command};
 use colored::Colorize;
 use ion_rs::binary::non_blocking::raw_binary_reader::RawBinaryReader;
 use ion_rs::element::writer::TextKind;
@@ -27,22 +27,10 @@ impl IonCliCommand for InspectCommand {
         "Displays hex-encoded binary Ion alongside its equivalent text for human-friendly debugging."
     }
 
-    fn clap_command(&self) -> Command {
-        Command::new(self.name())
-            .about(self.about())
-            .arg(
-                Arg::new("output")
-                    .long("output")
-                    .short('o')
-                    .help("Output file [default: STDOUT]"),
-            )
-            .arg(
-                Arg::new("input")
-                    .index(1)
-                    .trailing_var_arg(true)
-                    .action(ArgAction::Append)
-                    .help("Input file"),
-            )
+    fn configure_args(&self, command: Command) -> Command {
+        command
+            .with_input()
+            .with_output()
             .arg(
                 // This is named `skip-bytes` instead of `skip` to accommodate a future `skip-values` option.
                 Arg::new("skip-bytes")

--- a/src/bin/ion/commands/beta/mod.rs
+++ b/src/bin/ion/commands/beta/mod.rs
@@ -13,7 +13,7 @@ use crate::commands::beta::inspect::InspectCommand;
 use crate::commands::beta::primitive::PrimitiveCommand;
 use crate::commands::beta::schema::SchemaNamespace;
 use crate::commands::beta::to::ToNamespace;
-use crate::IonCliCommand;
+use crate::commands::IonCliCommand;
 
 pub struct BetaNamespace;
 

--- a/src/bin/ion/commands/beta/mod.rs
+++ b/src/bin/ion/commands/beta/mod.rs
@@ -6,63 +6,36 @@ pub mod primitive;
 pub mod schema;
 pub mod to;
 
-use crate::commands::CommandRunner;
-use anyhow::Result;
-use clap::{ArgMatches, Command};
+use crate::{IonCliCommand};
+use crate::commands::beta::count::CountCommand;
+use crate::commands::beta::from::FromNamespace;
+use crate::commands::beta::head::HeadCommand;
+use crate::commands::beta::inspect::InspectCommand;
+use crate::commands::beta::primitive::PrimitiveCommand;
+use crate::commands::beta::schema::SchemaNamespace;
+use crate::commands::beta::to::ToNamespace;
 
-// To add a beta subcommand, add your new command to the `beta_subcommands`
-// and `runner_for_beta_subcommands` functions.
 
-// Creates a Vec of CLI configurations for all of the available built-in commands
-pub fn beta_subcommands() -> Vec<Command> {
-    vec![
-        count::app(),
-        inspect::app(),
-        primitive::app(),
-        schema::app(),
-        head::app(),
-        from::app(),
-        to::app(),
-    ]
-}
+pub struct BetaNamespace;
 
-pub fn runner_for_beta_subcommand(command_name: &str) -> Option<CommandRunner> {
-    let runner = match command_name {
-        "count" => count::run,
-        "inspect" => inspect::run,
-        "primitive" => primitive::run,
-        "schema" => schema::run,
-        "from" => from::run,
-        "to" => to::run,
-        "head" => head::run,
-        _ => return None,
-    };
-    Some(runner)
-}
-
-// The functions below are used by the top-level `ion` command when `beta` is invoked.
-pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
-    //     ^-- At this level of dispatch, this command will always be the text `beta`.
-    // We want to evaluate the name of the subcommand that was invoked --v
-    let (command_name, command_args) = matches.subcommand().unwrap();
-    if let Some(runner) = runner_for_beta_subcommand(command_name) {
-        // If a runner is registered for the given command name, command_args is guaranteed to
-        // be defined; we can safely unwrap it.
-        runner(command_name, command_args)?;
-    } else {
-        let message = format!(
-            "The requested beta command ('{}') is not supported and clap did not generate an error message.",
-            command_name
-        );
-        unreachable!("{}", message);
+impl IonCliCommand for BetaNamespace {
+    fn name(&self) -> &'static str {
+        "beta"
     }
-    Ok(())
-}
 
-pub fn app() -> Command {
-    Command::new("beta")
-        .about(
-            "The 'beta' command is a namespace for commands whose interfaces are not yet stable.",
-        )
-        .subcommands(beta_subcommands())
+    fn about(&self) -> &'static str {
+        "The 'beta' command is a namespace for commands whose interfaces are not yet stable."
+    }
+
+    fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {
+        vec![
+            Box::new(CountCommand),
+            Box::new(InspectCommand),
+            Box::new(PrimitiveCommand),
+            Box::new(SchemaNamespace),
+            Box::new(HeadCommand),
+            Box::new(FromNamespace),
+            Box::new(ToNamespace),
+        ]
+    }
 }

--- a/src/bin/ion/commands/beta/mod.rs
+++ b/src/bin/ion/commands/beta/mod.rs
@@ -6,7 +6,6 @@ pub mod primitive;
 pub mod schema;
 pub mod to;
 
-use crate::{IonCliCommand};
 use crate::commands::beta::count::CountCommand;
 use crate::commands::beta::from::FromNamespace;
 use crate::commands::beta::head::HeadCommand;
@@ -14,7 +13,7 @@ use crate::commands::beta::inspect::InspectCommand;
 use crate::commands::beta::primitive::PrimitiveCommand;
 use crate::commands::beta::schema::SchemaNamespace;
 use crate::commands::beta::to::ToNamespace;
-
+use crate::IonCliCommand;
 
 pub struct BetaNamespace;
 

--- a/src/bin/ion/commands/beta/primitive.rs
+++ b/src/bin/ion/commands/beta/primitive.rs
@@ -15,9 +15,8 @@ impl IonCliCommand for PrimitiveCommand {
         "Prints the binary representation of an Ion encoding primitive."
     }
 
-    fn clap_command(&self) -> Command {
-        Command::new(self.name())
-            .about(self.about())
+    fn configure_args(&self, command: Command) -> Command {
+        command
             .arg(
                 Arg::new("type")
                     .short('t')

--- a/src/bin/ion/commands/beta/primitive.rs
+++ b/src/bin/ion/commands/beta/primitive.rs
@@ -1,4 +1,4 @@
-use crate::IonCliCommand;
+use crate::commands::IonCliCommand;
 use anyhow::{Context, Result};
 use clap::{Arg, ArgMatches, Command};
 use ion_rs::binary::var_int::VarInt;

--- a/src/bin/ion/commands/beta/primitive.rs
+++ b/src/bin/ion/commands/beta/primitive.rs
@@ -1,8 +1,8 @@
+use crate::IonCliCommand;
 use anyhow::{Context, Result};
 use clap::{Arg, ArgMatches, Command};
 use ion_rs::binary::var_int::VarInt;
 use ion_rs::binary::var_uint::VarUInt;
-use crate::IonCliCommand;
 
 pub struct PrimitiveCommand;
 

--- a/src/bin/ion/commands/beta/primitive.rs
+++ b/src/bin/ion/commands/beta/primitive.rs
@@ -2,59 +2,72 @@ use anyhow::{Context, Result};
 use clap::{Arg, ArgMatches, Command};
 use ion_rs::binary::var_int::VarInt;
 use ion_rs::binary::var_uint::VarUInt;
+use crate::IonCliCommand;
 
-pub fn app() -> Command {
-    Command::new("primitive")
-        .about("Prints the binary representation of an Ion encoding primitive.")
-        .arg(
-            Arg::new("type")
-                .short('t')
-                .required(true)
-                .help("The Ion primitive encoding type. (Names are case insensitive.)")
-                .value_parser(["VarInt", "varint", "VarUInt", "varuint"]),
-        )
-        .arg(
-            Arg::new("value")
-                .short('v')
-                .required(true)
-                .allow_hyphen_values(true)
-                .help("The value to encode as the specified primitive."),
-        )
-}
+pub struct PrimitiveCommand;
 
-pub fn run(_command_name: &str, matches: &ArgMatches) -> anyhow::Result<()> {
-    let mut buffer = Vec::new();
-    let value_text = matches.get_one::<String>("value").unwrap().as_str();
-    match matches.get_one::<String>("type").unwrap().as_str() {
-        "varuint" | "VarUInt" => {
-            let value = integer_from_text(value_text)? as u64;
-            VarUInt::write_u64(&mut buffer, value).unwrap();
-        }
-        "varint" | "VarInt" => {
-            let value = integer_from_text(value_text)?;
-            VarInt::write_i64(&mut buffer, value).unwrap();
-        }
-        unsupported => {
-            unreachable!(
-                "clap did not reject unsupported primitive encoding {}",
-                unsupported
-            );
-        }
+impl IonCliCommand for PrimitiveCommand {
+    fn name(&self) -> &'static str {
+        "primitive"
     }
-    print!("hex: ");
-    for byte in buffer.iter() {
-        // We want the hex bytes to align with the binary bytes that will be printed on the next
-        // line. Print 6 spaces and a 2-byte hex representation of the byte.
-        print!("      {:0>2x} ", byte);
+
+    fn about(&self) -> &'static str {
+        "Prints the binary representation of an Ion encoding primitive."
     }
-    println!();
-    print!("bin: ");
-    for byte in buffer.iter() {
-        // Print the binary representation of each byte
-        print!("{:0>8b} ", byte);
+
+    fn clap_command(&self) -> Command {
+        Command::new(self.name())
+            .about(self.about())
+            .arg(
+                Arg::new("type")
+                    .short('t')
+                    .required(true)
+                    .help("The Ion primitive encoding type. (Names are case insensitive.)")
+                    .value_parser(["VarInt", "varint", "VarUInt", "varuint"]),
+            )
+            .arg(
+                Arg::new("value")
+                    .short('v')
+                    .required(true)
+                    .allow_hyphen_values(true)
+                    .help("The value to encode as the specified primitive."),
+            )
     }
-    println!();
-    Ok(())
+
+    fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
+        let mut buffer = Vec::new();
+        let value_text = args.get_one::<String>("value").unwrap().as_str();
+        match args.get_one::<String>("type").unwrap().as_str() {
+            "varuint" | "VarUInt" => {
+                let value = integer_from_text(value_text)? as u64;
+                VarUInt::write_u64(&mut buffer, value).unwrap();
+            }
+            "varint" | "VarInt" => {
+                let value = integer_from_text(value_text)?;
+                VarInt::write_i64(&mut buffer, value).unwrap();
+            }
+            unsupported => {
+                unreachable!(
+                    "clap did not reject unsupported primitive encoding {}",
+                    unsupported
+                );
+            }
+        }
+        print!("hex: ");
+        for byte in buffer.iter() {
+            // We want the hex bytes to align with the binary bytes that will be printed on the next
+            // line. Print 6 spaces and a 2-byte hex representation of the byte.
+            print!("      {:0>2x} ", byte);
+        }
+        println!();
+        print!("bin: ");
+        for byte in buffer.iter() {
+            // Print the binary representation of each byte
+            print!("{:0>8b} ", byte);
+        }
+        println!();
+        Ok(())
+    }
 }
 
 fn integer_from_text(text: &str) -> Result<i64> {

--- a/src/bin/ion/commands/beta/schema/load.rs
+++ b/src/bin/ion/commands/beta/schema/load.rs
@@ -1,9 +1,9 @@
+use crate::IonCliCommand;
 use anyhow::Result;
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use ion_schema::authority::{DocumentAuthority, FileSystemDocumentAuthority};
 use ion_schema::system::SchemaSystem;
 use std::path::Path;
-use crate::IonCliCommand;
 
 pub struct LoadCommand;
 

--- a/src/bin/ion/commands/beta/schema/load.rs
+++ b/src/bin/ion/commands/beta/schema/load.rs
@@ -1,4 +1,4 @@
-use crate::IonCliCommand;
+use crate::commands::IonCliCommand;
 use anyhow::Result;
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use ion_schema::authority::{DocumentAuthority, FileSystemDocumentAuthority};

--- a/src/bin/ion/commands/beta/schema/load.rs
+++ b/src/bin/ion/commands/beta/schema/load.rs
@@ -17,9 +17,8 @@ impl IonCliCommand for LoadCommand {
         Shows an error message if there were any invalid schema syntax found during the load process"#
     }
 
-    fn clap_command(&self) -> Command {
-        Command::new(self.name())
-            .about(self.about())
+    fn configure_args(&self, command: Command) -> Command {
+        command
             .arg(
                 // Input file can be specified by the "-s" or "--schema" flags.
                 Arg::new("schema")

--- a/src/bin/ion/commands/beta/schema/load.rs
+++ b/src/bin/ion/commands/beta/schema/load.rs
@@ -3,59 +3,67 @@ use clap::{Arg, ArgAction, ArgMatches, Command};
 use ion_schema::authority::{DocumentAuthority, FileSystemDocumentAuthority};
 use ion_schema::system::SchemaSystem;
 use std::path::Path;
+use crate::IonCliCommand;
 
-const ABOUT: &str = "Loads an Ion Schema file using user provided schema id and returns a result message. Shows an error message if there were any invalid schema syntax found during the load process";
+pub struct LoadCommand;
 
-// Creates a `clap` (Command Line Arguments Parser) configuration for the `load` command.
-// This function is invoked by the `load` command's parent `schema`, so it can describe its
-// child commands.
-pub fn app() -> Command {
-    Command::new("load")
-        .about(ABOUT)
-        .arg(
-            // Input file can be specified by the "-s" or "--schema" flags.
-            Arg::new("schema")
-                .long("schema")
-                .short('s')
-                .required(true)
-                .value_name("SCHEMA")
-                .help("The Ion Schema file to load"),
-        )
-        .arg(
-            // Directory(s) that will be used as authority(s) for schema system
-            Arg::new("directories")
-                .long("directory")
-                .short('d')
-                // If this appears more than once, collect all values
-                .action(ArgAction::Append)
-                .value_name("DIRECTORY")
-                .required(true)
-                .help("One or more directories that will be searched for the requested schema"),
-        )
-}
-
-// This function is invoked by the `load` command's parent `schema`.
-pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
-    // Extract the user provided document authorities/ directories
-    let authorities: Vec<&String> = matches.get_many("directories").unwrap().collect();
-
-    // Extract schema file provided by user
-    let schema_id = matches.get_one::<String>("schema").unwrap();
-
-    // Set up document authorities vector
-    let mut document_authorities: Vec<Box<dyn DocumentAuthority>> = vec![];
-
-    for authority in authorities {
-        document_authorities.push(Box::new(FileSystemDocumentAuthority::new(Path::new(
-            authority,
-        ))))
+impl IonCliCommand for LoadCommand {
+    fn name(&self) -> &'static str {
+        "load"
     }
 
-    // Create a new schema system from given document authorities
-    let mut schema_system = SchemaSystem::new(document_authorities);
+    fn about(&self) -> &'static str {
+        r#"Loads an Ion Schema file using user provided schema id and returns a result message.\
+        Shows an error message if there were any invalid schema syntax found during the load process"#
+    }
 
-    // load given schema
-    println!("Schema: {:#?}", schema_system.load_schema(schema_id)?);
+    fn clap_command(&self) -> Command {
+        Command::new(self.name())
+            .about(self.about())
+            .arg(
+                // Input file can be specified by the "-s" or "--schema" flags.
+                Arg::new("schema")
+                    .long("schema")
+                    .short('s')
+                    .required(true)
+                    .value_name("SCHEMA")
+                    .help("The Ion Schema file to load"),
+            )
+            .arg(
+                // Directory(s) that will be used as authority(s) for schema system
+                Arg::new("directories")
+                    .long("directory")
+                    .short('d')
+                    // If this appears more than once, collect all values
+                    .action(ArgAction::Append)
+                    .value_name("DIRECTORY")
+                    .required(true)
+                    .help("One or more directories that will be searched for the requested schema"),
+            )
+    }
 
-    Ok(())
+    fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
+        // Extract the user provided document authorities/ directories
+        let authorities: Vec<&String> = args.get_many("directories").unwrap().collect();
+
+        // Extract schema file provided by user
+        let schema_id = args.get_one::<String>("schema").unwrap();
+
+        // Set up document authorities vector
+        let mut document_authorities: Vec<Box<dyn DocumentAuthority>> = vec![];
+
+        for authority in authorities {
+            document_authorities.push(Box::new(FileSystemDocumentAuthority::new(Path::new(
+                authority,
+            ))))
+        }
+
+        // Create a new schema system from given document authorities
+        let mut schema_system = SchemaSystem::new(document_authorities);
+
+        // load given schema
+        println!("Schema: {:#?}", schema_system.load_schema(schema_id)?);
+
+        Ok(())
+    }
 }

--- a/src/bin/ion/commands/beta/schema/load.rs
+++ b/src/bin/ion/commands/beta/schema/load.rs
@@ -13,8 +13,8 @@ impl IonCliCommand for LoadCommand {
     }
 
     fn about(&self) -> &'static str {
-        r#"Loads an Ion Schema file using user provided schema id and returns a result message.\
-        Shows an error message if there were any invalid schema syntax found during the load process"#
+        r#"Loads an Ion Schema file indicated by a user-provided schema ID and outputs a result message.\
+        Shows an error message if any invalid schema syntax was found during the load process."#
     }
 
     fn configure_args(&self, command: Command) -> Command {

--- a/src/bin/ion/commands/beta/schema/mod.rs
+++ b/src/bin/ion/commands/beta/schema/mod.rs
@@ -1,7 +1,7 @@
 pub mod load;
 pub mod validate;
 
-use crate::IonCliCommand;
+use crate::commands::IonCliCommand;
 
 use crate::commands::beta::schema::load::LoadCommand;
 use crate::commands::beta::schema::validate::ValidateCommand;

--- a/src/bin/ion/commands/beta/schema/mod.rs
+++ b/src/bin/ion/commands/beta/schema/mod.rs
@@ -14,7 +14,7 @@ impl IonCliCommand for SchemaNamespace {
     }
 
     fn about(&self) -> &'static str {
-        "The 'schema' command is a namespace for commands that are related to schema sandbox"
+        "The 'schema' command is a namespace for commands that are related to Ion Schema"
     }
 
     fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {

--- a/src/bin/ion/commands/beta/schema/mod.rs
+++ b/src/bin/ion/commands/beta/schema/mod.rs
@@ -14,7 +14,7 @@ impl IonCliCommand for SchemaNamespace {
     }
 
     fn about(&self) -> &'static str {
-        "The 'schema' command is a namespace for commands that are related to Ion Schema"
+        "The 'schema' command is a namespace for commands that are related to Ion Schema."
     }
 
     fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {

--- a/src/bin/ion/commands/beta/schema/mod.rs
+++ b/src/bin/ion/commands/beta/schema/mod.rs
@@ -1,49 +1,27 @@
 pub mod load;
 pub mod validate;
 
-use crate::commands::CommandRunner;
-use anyhow::Result;
-use clap::{ArgMatches, Command};
+use crate::{IonCliCommand};
 
-// To add a schema subcommand, add your new command to the `schema_subcommands`
-// and `runner_for_schema_subcommands` functions.
 
-// Creates a Vec of CLI configurations for all of the available built-in subcommands for schema
-pub fn schema_subcommands() -> Vec<Command> {
-    vec![load::app(), validate::app()]
-}
+use crate::commands::beta::schema::load::LoadCommand;
+use crate::commands::beta::schema::validate::ValidateCommand;
 
-pub fn runner_for_schema_subcommand(command_name: &str) -> Option<CommandRunner> {
-    let runner = match command_name {
-        "load" => load::run,
-        "validate" => validate::run,
-        _ => return None,
-    };
-    Some(runner)
-}
+pub struct SchemaNamespace;
 
-// The functions below are used by the `beta` subcommand when `schema` is invoked.
-pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
-    // We want to evaluate the name of the subcommand that was invoked
-    let (command_name, command_args) = matches.subcommand().unwrap();
-    if let Some(runner) = runner_for_schema_subcommand(command_name) {
-        // If a runner is registered for the given command name, command_args is guaranteed to
-        // be defined; we can safely unwrap it.
-        runner(command_name, command_args)?;
-    } else {
-        let message = format!(
-            "The requested schema command ('{}') is not supported and clap did not generate an error message.",
-            command_name
-        );
-        unreachable!("{}", message);
+impl IonCliCommand for SchemaNamespace {
+    fn name(&self) -> &'static str {
+        "schema"
     }
-    Ok(())
-}
 
-pub fn app() -> Command {
-    Command::new("schema")
-        .about(
-            "The 'schema' command is a namespace for commands that are related to schema sandbox",
-        )
-        .subcommands(schema_subcommands())
+    fn about(&self) -> &'static str {
+        "The 'schema' command is a namespace for commands that are related to schema sandbox"
+    }
+
+    fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {
+        vec![
+            Box::new(LoadCommand),
+            Box::new(ValidateCommand),
+        ]
+    }
 }

--- a/src/bin/ion/commands/beta/schema/mod.rs
+++ b/src/bin/ion/commands/beta/schema/mod.rs
@@ -1,8 +1,7 @@
 pub mod load;
 pub mod validate;
 
-use crate::{IonCliCommand};
-
+use crate::IonCliCommand;
 
 use crate::commands::beta::schema::load::LoadCommand;
 use crate::commands::beta::schema::validate::ValidateCommand;
@@ -19,9 +18,6 @@ impl IonCliCommand for SchemaNamespace {
     }
 
     fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {
-        vec![
-            Box::new(LoadCommand),
-            Box::new(ValidateCommand),
-        ]
+        vec![Box::new(LoadCommand), Box::new(ValidateCommand)]
     }
 }

--- a/src/bin/ion/commands/beta/schema/validate.rs
+++ b/src/bin/ion/commands/beta/schema/validate.rs
@@ -23,9 +23,17 @@ impl IonCliCommand for ValidateCommand {
         "Validates an Ion value based on a given Ion Schema type."
     }
 
-    fn clap_command(&self) -> Command {
-        Command::new(self.name())
-            .about(self.about())
+    fn configure_args(&self, command: Command) -> Command {
+        command
+            .arg(
+                // Input ion file can be specified by the "-i" or "--input" flags.
+                Arg::new("input")
+                    .long("input")
+                    .short('i')
+                    .required(true)
+                    .value_name("INPUT_FILE")
+                    .help("Input file containing the Ion values to be validated"),
+            )
             .arg(
                 // Schema file can be specified by the "-s" or "--schema" flags.
                 Arg::new("schema")
@@ -44,15 +52,6 @@ impl IonCliCommand for ValidateCommand {
                     .value_name("DIRECTORY")
                     .required(true)
                     .help("One or more directories that will be searched for the requested schema"),
-            )
-            .arg(
-                // Input ion file can be specified by the "-i" or "--input" flags.
-                Arg::new("input")
-                    .long("input")
-                    .short('i')
-                    .required(true)
-                    .value_name("INPUT_FILE")
-                    .help("Input file containing the Ion values to be validated"),
             )
             .arg(
                 // Schema Type can be specified by the "-t" or "--type" flags.

--- a/src/bin/ion/commands/beta/schema/validate.rs
+++ b/src/bin/ion/commands/beta/schema/validate.rs
@@ -1,3 +1,4 @@
+use crate::IonCliCommand;
 use anyhow::{Context, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use ion_schema::authority::{DocumentAuthority, FileSystemDocumentAuthority};
@@ -10,7 +11,6 @@ use ion_schema::system::SchemaSystem;
 use std::fs;
 use std::path::Path;
 use std::str::from_utf8;
-use crate::IonCliCommand;
 
 pub struct ValidateCommand;
 
@@ -77,7 +77,8 @@ impl IonCliCommand for ValidateCommand {
 
         // Extract Ion value provided by user
         let input_file = args.get_one::<String>("input").unwrap();
-        let value = fs::read(input_file).with_context(|| format!("Could not open '{}'", schema_id))?;
+        let value =
+            fs::read(input_file).with_context(|| format!("Could not open '{}'", schema_id))?;
         let owned_elements: Vec<Element> = ReaderBuilder::new()
             .build(value.as_slice())?
             .read_all_elements()

--- a/src/bin/ion/commands/beta/schema/validate.rs
+++ b/src/bin/ion/commands/beta/schema/validate.rs
@@ -1,4 +1,4 @@
-use crate::IonCliCommand;
+use crate::commands::IonCliCommand;
 use anyhow::{Context, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use ion_schema::authority::{DocumentAuthority, FileSystemDocumentAuthority};

--- a/src/bin/ion/commands/beta/schema/validate.rs
+++ b/src/bin/ion/commands/beta/schema/validate.rs
@@ -10,123 +10,130 @@ use ion_schema::system::SchemaSystem;
 use std::fs;
 use std::path::Path;
 use std::str::from_utf8;
+use crate::IonCliCommand;
 
-const ABOUT: &str = "validates an Ion Value based on given Ion Schema Type";
+pub struct ValidateCommand;
 
-// Creates a `clap` (Command Line Arguments Parser) configuration for the `load` command.
-// This function is invoked by the `load` command's parent `schema`, so it can describe its
-// child commands.
-pub fn app() -> Command {
-    Command::new("validate")
-        .about(ABOUT)
-        .arg(
-            // Schema file can be specified by the "-s" or "--schema" flags.
-            Arg::new("schema")
-                .long("schema")
-                .short('s')
-                .required(true)
-                .value_name("SCHEMA")
-                .help("The Ion Schema file to load"),
-        )
-        .arg(
-            // Directory(s) that will be used as authority(s) for schema system
-            Arg::new("directories")
-                .long("directory")
-                .short('d')
-                .action(ArgAction::Append)
-                .value_name("DIRECTORY")
-                .required(true)
-                .help("One or more directories that will be searched for the requested schema"),
-        )
-        .arg(
-            // Input ion file can be specified by the "-i" or "--input" flags.
-            Arg::new("input")
-                .long("input")
-                .short('i')
-                .required(true)
-                .value_name("INPUT_FILE")
-                .help("Input file containing the Ion values to be validated"),
-        )
-        .arg(
-            // Schema Type can be specified by the "-t" or "--type" flags.
-            Arg::new("type")
-                .long("type")
-                .short('t')
-                .required(true)
-                .value_name("TYPE")
-                .help("Name of schema type from given schema that needs to be used for validation"),
-        )
-}
-
-// This function is invoked by the `load` command's parent `schema`.
-pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
-    // Extract the user provided document authorities/ directories
-    let authorities: Vec<&String> = matches.get_many("directories").unwrap().collect();
-
-    // Extract schema file provided by user
-    let schema_id = matches.get_one::<String>("schema").unwrap();
-
-    // Extract the schema type provided by user
-    let schema_type = matches.get_one::<String>("type").unwrap();
-
-    // Extract Ion value provided by user
-    let input_file = matches.get_one::<String>("input").unwrap();
-    let value = fs::read(input_file).with_context(|| format!("Could not open '{}'", schema_id))?;
-    let owned_elements: Vec<Element> = ReaderBuilder::new()
-        .build(value.as_slice())?
-        .read_all_elements()
-        .with_context(|| format!("Could not parse Ion file: '{}'", schema_id))?;
-
-    // Set up document authorities vector
-    let mut document_authorities: Vec<Box<dyn DocumentAuthority>> = vec![];
-
-    for authority in authorities {
-        document_authorities.push(Box::new(FileSystemDocumentAuthority::new(Path::new(
-            authority,
-        ))))
+impl IonCliCommand for ValidateCommand {
+    fn name(&self) -> &'static str {
+        "validate"
     }
 
-    // Create a new schema system from given document authorities
-    let mut schema_system = SchemaSystem::new(document_authorities);
+    fn about(&self) -> &'static str {
+        "Validates an Ion value based on a given Ion Schema type."
+    }
 
-    // load schema
-    let schema = schema_system.load_schema(schema_id);
+    fn clap_command(&self) -> Command {
+        Command::new(self.name())
+            .about(self.about())
+            .arg(
+                // Schema file can be specified by the "-s" or "--schema" flags.
+                Arg::new("schema")
+                    .long("schema")
+                    .short('s')
+                    .required(true)
+                    .value_name("SCHEMA")
+                    .help("The Ion Schema file to load"),
+            )
+            .arg(
+                // Directory(s) that will be used as authority(s) for schema system
+                Arg::new("directories")
+                    .long("directory")
+                    .short('d')
+                    .action(ArgAction::Append)
+                    .value_name("DIRECTORY")
+                    .required(true)
+                    .help("One or more directories that will be searched for the requested schema"),
+            )
+            .arg(
+                // Input ion file can be specified by the "-i" or "--input" flags.
+                Arg::new("input")
+                    .long("input")
+                    .short('i')
+                    .required(true)
+                    .value_name("INPUT_FILE")
+                    .help("Input file containing the Ion values to be validated"),
+            )
+            .arg(
+                // Schema Type can be specified by the "-t" or "--type" flags.
+                Arg::new("type")
+                    .long("type")
+                    .short('t')
+                    .required(true)
+                    .value_name("TYPE")
+                    .help("Name of schema type from given schema that needs to be used for validation"),
+            )
+    }
 
-    // get the type provided by user from the schema file
-    let type_ref = schema?
-        .get_type(schema_type)
-        .with_context(|| format!("Schema {} does not have type {}", schema_id, schema_type))?;
+    fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
+        // Extract the user provided document authorities/ directories
+        let authorities: Vec<&String> = args.get_many("directories").unwrap().collect();
 
-    // create a text writer to make the output
-    let mut output = vec![];
-    let mut writer = TextWriterBuilder::new().build(&mut output)?;
+        // Extract schema file provided by user
+        let schema_id = args.get_one::<String>("schema").unwrap();
 
-    // validate owned_elements according to type_ref
-    for owned_element in owned_elements {
-        // create a validation report with validation result, value, schema and/or violation
-        writer.step_in(IonType::Struct)?;
-        let validation_result = type_ref.validate(&owned_element);
-        writer.set_field_name("result");
-        match validation_result {
-            Ok(_) => {
-                writer.write_string("Valid")?;
-                writer.set_field_name("value");
-                writer.write_string(element_to_string(&owned_element)?)?;
-                writer.set_field_name("schema");
-                writer.write_string(schema_id)?;
-            }
-            Err(error) => {
-                writer.write_string("Invalid")?;
-                writer.set_field_name("violation");
-                writer.write_string(format!("{:#?}", error))?;
-            }
+        // Extract the schema type provided by user
+        let schema_type = args.get_one::<String>("type").unwrap();
+
+        // Extract Ion value provided by user
+        let input_file = args.get_one::<String>("input").unwrap();
+        let value = fs::read(input_file).with_context(|| format!("Could not open '{}'", schema_id))?;
+        let owned_elements: Vec<Element> = ReaderBuilder::new()
+            .build(value.as_slice())?
+            .read_all_elements()
+            .with_context(|| format!("Could not parse Ion file: '{}'", schema_id))?;
+
+        // Set up document authorities vector
+        let mut document_authorities: Vec<Box<dyn DocumentAuthority>> = vec![];
+
+        for authority in authorities {
+            document_authorities.push(Box::new(FileSystemDocumentAuthority::new(Path::new(
+                authority,
+            ))))
         }
-        writer.step_out()?;
+
+        // Create a new schema system from given document authorities
+        let mut schema_system = SchemaSystem::new(document_authorities);
+
+        // load schema
+        let schema = schema_system.load_schema(schema_id);
+
+        // get the type provided by user from the schema file
+        let type_ref = schema?
+            .get_type(schema_type)
+            .with_context(|| format!("Schema {} does not have type {}", schema_id, schema_type))?;
+
+        // create a text writer to make the output
+        let mut output = vec![];
+        let mut writer = TextWriterBuilder::new().build(&mut output)?;
+
+        // validate owned_elements according to type_ref
+        for owned_element in owned_elements {
+            // create a validation report with validation result, value, schema and/or violation
+            writer.step_in(IonType::Struct)?;
+            let validation_result = type_ref.validate(&owned_element);
+            writer.set_field_name("result");
+            match validation_result {
+                Ok(_) => {
+                    writer.write_string("Valid")?;
+                    writer.set_field_name("value");
+                    writer.write_string(element_to_string(&owned_element)?)?;
+                    writer.set_field_name("schema");
+                    writer.write_string(schema_id)?;
+                }
+                Err(error) => {
+                    writer.write_string("Invalid")?;
+                    writer.set_field_name("violation");
+                    writer.write_string(format!("{:#?}", error))?;
+                }
+            }
+            writer.step_out()?;
+        }
+        drop(writer);
+        println!("Validation report:");
+        println!("{}", from_utf8(&output).unwrap());
+        Ok(())
     }
-    drop(writer);
-    println!("Validation report:");
-    println!("{}", from_utf8(&output).unwrap());
-    Ok(())
 }
 
 // TODO: this will be provided by Element's implementation of `Display` in a future

--- a/src/bin/ion/commands/beta/to/json.rs
+++ b/src/bin/ion/commands/beta/to/json.rs
@@ -1,4 +1,4 @@
-use crate::IonCliCommand;
+use crate::commands::IonCliCommand;
 use anyhow::{Context, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use ion_rs::element::reader::ElementReader;

--- a/src/bin/ion/commands/beta/to/json.rs
+++ b/src/bin/ion/commands/beta/to/json.rs
@@ -1,3 +1,4 @@
+use crate::IonCliCommand;
 use anyhow::{Context, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use ion_rs::element::reader::ElementReader;
@@ -7,7 +8,6 @@ use serde_json::{Map, Number, Value as JsonValue};
 use std::fs::File;
 use std::io::{stdin, stdout, BufWriter, Write};
 use std::str::FromStr;
-use crate::IonCliCommand;
 
 pub struct ToJsonCommand;
 

--- a/src/bin/ion/commands/beta/to/json.rs
+++ b/src/bin/ion/commands/beta/to/json.rs
@@ -1,6 +1,6 @@
-use crate::commands::IonCliCommand;
+use crate::commands::{IonCliCommand, WithIonCliArgument};
 use anyhow::{Context, Result};
-use clap::{Arg, ArgAction, ArgMatches, Command};
+use clap::{ArgMatches, Command};
 use ion_rs::element::reader::ElementReader;
 use ion_rs::element::Element;
 use ion_rs::{Reader, ReaderBuilder};
@@ -20,25 +20,10 @@ impl IonCliCommand for ToJsonCommand {
         "Converts Ion data to JSON."
     }
 
-    fn clap_command(&self) -> Command {
-        Command::new(self.name())
-            .about(self.about())
-            .arg(
-                Arg::new("output")
-                    .long("output")
-                    .short('o')
-                    .help("Output file [default: STDOUT]"),
-            )
-            .arg(
-                // Unlabeled positional arguments will also be considered input file names.
-                Arg::new("input")
-                    .index(1)
-                    .trailing_var_arg(true)
-                    .action(ArgAction::Append)
-                    .help("Input file name"),
-            )
+    fn configure_args(&self, command: Command) -> Command {
         // NOTE: it may be necessary to add format-specific options. For example, a "pretty" option
         // would make sense for JSON, but not binary formats like CBOR.
+        command.with_input().with_output()
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {

--- a/src/bin/ion/commands/beta/to/json.rs
+++ b/src/bin/ion/commands/beta/to/json.rs
@@ -7,65 +7,76 @@ use serde_json::{Map, Number, Value as JsonValue};
 use std::fs::File;
 use std::io::{stdin, stdout, BufWriter, Write};
 use std::str::FromStr;
+use crate::IonCliCommand;
 
-const ABOUT: &str = "Converts Ion data to JSON.";
+pub struct ToJsonCommand;
 
-pub fn app() -> Command {
-    Command::new("json")
-        .about(ABOUT)
-        .arg(
-            Arg::new("output")
-                .long("output")
-                .short('o')
-                .help("Output file [default: STDOUT]"),
-        )
-        .arg(
-            // Unlabeled positional arguments will also be considered input file names.
-            Arg::new("input")
-                .index(1)
-                .trailing_var_arg(true)
-                .action(ArgAction::Append)
-                .help("Input file name"),
-        )
-    // NOTE: it may be necessary to add format-specific options. For example, a "pretty" option
-    // would make sense for JSON, but not binary formats like CBOR.
-}
-
-pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
-    // Look for an output file name specified with `-o`
-    let mut output: Box<dyn Write> = if let Some(output_file) = matches.get_one::<String>("output")
-    {
-        let file = File::create(output_file).with_context(|| {
-            format!(
-                "could not open file output file '{}' for writing",
-                output_file
-            )
-        })?;
-        Box::new(BufWriter::new(file))
-    } else {
-        Box::new(stdout().lock())
-    };
-
-    if let Some(input_file_names) = matches.get_many::<String>("input") {
-        // Input files were specified, run the converter on each of them in turn
-        for input_file in input_file_names {
-            let file = File::open(input_file.as_str())
-                .with_context(|| format!("Could not open file '{}'", &input_file))?;
-            let mut reader = ReaderBuilder::new()
-                .build(file)
-                .with_context(|| format!("Input file {} was not valid Ion.", &input_file))?;
-            convert(&mut reader, &mut output)?;
-        }
-    } else {
-        // No input files were specified, run the converter on STDIN.
-        let mut reader = ReaderBuilder::new()
-            .build(stdin().lock())
-            .with_context(|| "Input was not valid Ion.")?;
-        convert(&mut reader, &mut output)?;
+impl IonCliCommand for ToJsonCommand {
+    fn name(&self) -> &'static str {
+        "json"
     }
 
-    output.flush()?;
-    Ok(())
+    fn about(&self) -> &'static str {
+        "Converts Ion data to JSON."
+    }
+
+    fn clap_command(&self) -> Command {
+        Command::new(self.name())
+            .about(self.about())
+            .arg(
+                Arg::new("output")
+                    .long("output")
+                    .short('o')
+                    .help("Output file [default: STDOUT]"),
+            )
+            .arg(
+                // Unlabeled positional arguments will also be considered input file names.
+                Arg::new("input")
+                    .index(1)
+                    .trailing_var_arg(true)
+                    .action(ArgAction::Append)
+                    .help("Input file name"),
+            )
+        // NOTE: it may be necessary to add format-specific options. For example, a "pretty" option
+        // would make sense for JSON, but not binary formats like CBOR.
+    }
+
+    fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
+        // Look for an output file name specified with `-o`
+        let mut output: Box<dyn Write> = if let Some(output_file) = args.get_one::<String>("output")
+        {
+            let file = File::create(output_file).with_context(|| {
+                format!(
+                    "could not open file output file '{}' for writing",
+                    output_file
+                )
+            })?;
+            Box::new(BufWriter::new(file))
+        } else {
+            Box::new(stdout().lock())
+        };
+
+        if let Some(input_file_names) = args.get_many::<String>("input") {
+            // Input files were specified, run the converter on each of them in turn
+            for input_file in input_file_names {
+                let file = File::open(input_file.as_str())
+                    .with_context(|| format!("Could not open file '{}'", &input_file))?;
+                let mut reader = ReaderBuilder::new()
+                    .build(file)
+                    .with_context(|| format!("Input file {} was not valid Ion.", &input_file))?;
+                convert(&mut reader, &mut output)?;
+            }
+        } else {
+            // No input files were specified, run the converter on STDIN.
+            let mut reader = ReaderBuilder::new()
+                .build(stdin().lock())
+                .with_context(|| "Input was not valid Ion.")?;
+            convert(&mut reader, &mut output)?;
+        }
+
+        output.flush()?;
+        Ok(())
+    }
 }
 
 pub fn convert(reader: &mut Reader, output: &mut Box<dyn Write>) -> Result<()> {

--- a/src/bin/ion/commands/beta/to/mod.rs
+++ b/src/bin/ion/commands/beta/to/mod.rs
@@ -1,5 +1,4 @@
-use crate::{IonCliCommand};
-
+use crate::IonCliCommand;
 
 use crate::commands::beta::to::json::ToJsonCommand;
 

--- a/src/bin/ion/commands/beta/to/mod.rs
+++ b/src/bin/ion/commands/beta/to/mod.rs
@@ -1,4 +1,4 @@
-use crate::IonCliCommand;
+use crate::commands::IonCliCommand;
 
 use crate::commands::beta::to::json::ToJsonCommand;
 

--- a/src/bin/ion/commands/beta/to/mod.rs
+++ b/src/bin/ion/commands/beta/to/mod.rs
@@ -1,42 +1,22 @@
-use crate::commands::CommandRunner;
-use anyhow::Result;
-use clap::{ArgMatches, Command};
+use crate::{IonCliCommand};
+
+
+use crate::commands::beta::to::json::ToJsonCommand;
 
 pub mod json;
 
-// Creates a Vec of CLI configurations for all of the available built-in commands
-pub fn subcommands() -> Vec<Command> {
-    vec![json::app()]
-}
+pub struct ToNamespace;
 
-// Maps the given command name to the entry point for that command if it exists
-pub fn runner_for_to_command(command_name: &str) -> Option<CommandRunner> {
-    let runner = match command_name {
-        "json" => json::run,
-        _ => return None,
-    };
-    Some(runner)
-}
-
-// The functions below are used by the parent `beta` command when `to` is invoked.
-pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
-    //     ^-- At this level of dispatch, this command will always be the text `to`.
-    // We want to evaluate the name of the subcommand that was invoked --v
-    let (command_name, command_args) = matches.subcommand().unwrap();
-    if let Some(runner) = runner_for_to_command(command_name) {
-        runner(command_name, command_args)?;
-    } else {
-        let message = format!(
-            "The requested `to` command ('{}') is not supported and clap did not generate an error message.",
-            command_name
-        );
-        unreachable!("{}", message);
+impl IonCliCommand for ToNamespace {
+    fn name(&self) -> &'static str {
+        "to"
     }
-    Ok(())
-}
 
-pub fn app() -> Command {
-    Command::new("to")
-        .about("'to' is a namespace for commands that convert Ion to another data format.")
-        .subcommands(subcommands())
+    fn about(&self) -> &'static str {
+        "'to' is a namespace for commands that convert Ion to another data format."
+    }
+
+    fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {
+        vec![Box::new(ToJsonCommand)]
+    }
 }

--- a/src/bin/ion/commands/dump.rs
+++ b/src/bin/ion/commands/dump.rs
@@ -1,6 +1,6 @@
-use crate::commands::IonCliCommand;
+use crate::commands::{IonCliCommand, WithIonCliArgument};
 use anyhow::{Context, Result};
-use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
+use clap::{value_parser, Arg, ArgMatches, Command};
 use ion_rs::*;
 use std::fs::File;
 use std::io::{stdin, stdout, StdinLock, Write};
@@ -16,10 +16,9 @@ impl IonCliCommand for DumpCommand {
         "Prints Ion in the requested format"
     }
 
-    fn clap_command(&self) -> Command {
-        Command::new(self.name())
-            .about(self.about())
-            //TODO: Remove `values` after https://github.com/amazon-ion/ion-cli/issues/49
+    fn configure_args(&self, command: Command) -> Command {
+        //TODO: Remove `values` after https://github.com/amazon-ion/ion-cli/issues/49
+        command
             .arg(
                 Arg::new("values")
                     .long("values")
@@ -29,29 +28,9 @@ impl IonCliCommand for DumpCommand {
                     .hide(true)
                     .help("Specifies the number of output top-level values."),
             )
-            .arg(
-                Arg::new("format")
-                    .long("format")
-                    .short('f')
-                    .default_value("pretty")
-                    .value_parser(["binary", "text", "pretty", "lines"])
-                    .help("Output format"),
-            )
-            .arg(
-                Arg::new("output")
-                    .long("output")
-                    .short('o')
-                    .help("Output file [default: STDOUT]"),
-            )
-            .arg(
-                // All argv entries after the program name (argv[0])
-                // and any `clap`-managed options are considered input files.
-                Arg::new("input")
-                    .index(1)
-                    .help("Input file [default: STDIN]")
-                    .action(ArgAction::Append)
-                    .trailing_var_arg(true),
-            )
+            .with_input()
+            .with_output()
+            .with_format()
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {

--- a/src/bin/ion/commands/dump.rs
+++ b/src/bin/ion/commands/dump.rs
@@ -13,7 +13,7 @@ impl IonCliCommand for DumpCommand {
     }
 
     fn about(&self) -> &'static str {
-        "Prints Ion in the requested format"
+        "Prints Ion in the requested format."
     }
 
     fn configure_args(&self, command: Command) -> Command {

--- a/src/bin/ion/commands/dump.rs
+++ b/src/bin/ion/commands/dump.rs
@@ -1,9 +1,9 @@
+use crate::IonCliCommand;
 use anyhow::{Context, Result};
 use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 use ion_rs::*;
 use std::fs::File;
 use std::io::{stdin, stdout, StdinLock, Write};
-use crate::IonCliCommand;
 
 pub struct DumpCommand;
 

--- a/src/bin/ion/commands/dump.rs
+++ b/src/bin/ion/commands/dump.rs
@@ -1,4 +1,4 @@
-use crate::IonCliCommand;
+use crate::commands::IonCliCommand;
 use anyhow::{Context, Result};
 use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 use ion_rs::*;

--- a/src/bin/ion/commands/dump.rs
+++ b/src/bin/ion/commands/dump.rs
@@ -3,83 +3,104 @@ use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 use ion_rs::*;
 use std::fs::File;
 use std::io::{stdin, stdout, StdinLock, Write};
+use crate::IonCliCommand;
 
-pub fn app() -> Command {
-    Command::new("dump")
-        .about("Prints Ion in the requested format")
-        //TODO: Remove `values` after https://github.com/amazon-ion/ion-cli/issues/49
-        .arg(
-            Arg::new("values")
-                .long("values")
-                .short('n')
-                .value_parser(value_parser!(usize))
-                .allow_negative_numbers(false)
-                .hide(true)
-                .help("Specifies the number of output top-level values."),
-        )
-        .arg(
-            Arg::new("format")
-                .long("format")
-                .short('f')
-                .default_value("pretty")
-                .value_parser(["binary", "text", "pretty", "lines"])
-                .help("Output format"),
-        )
-        .arg(
-            Arg::new("output")
-                .long("output")
-                .short('o')
-                .help("Output file [default: STDOUT]"),
-        )
-        .arg(
-            // All argv entries after the program name (argv[0])
-            // and any `clap`-managed options are considered input files.
-            Arg::new("input")
-                .index(1)
-                .help("Input file [default: STDIN]")
-                .action(ArgAction::Append)
-                .trailing_var_arg(true),
-        )
-}
+pub struct DumpCommand;
 
-pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
-    // --format pretty|text|lines|binary
-    // `clap` validates the specified format and provides a default otherwise.
-    let format = matches.get_one::<String>("format").unwrap();
-
-    // --values <n>
-    // this value is supplied when `dump` is invoked as `head`
-    let values: Option<usize> = matches.get_one::<usize>("values").copied();
-
-    // -o filename
-    let mut output: Box<dyn Write> = if let Some(output_file) = matches.get_one::<String>("output")
-    {
-        let file = File::create(output_file).with_context(|| {
-            format!(
-                "could not open file output file '{}' for writing",
-                output_file
-            )
-        })?;
-        Box::new(file)
-    } else {
-        Box::new(stdout().lock())
-    };
-
-    if let Some(input_file_iter) = matches.get_many::<String>("input") {
-        for input_file in input_file_iter {
-            let file = File::open(input_file)
-                .with_context(|| format!("Could not open file '{}'", input_file))?;
-            let mut reader = ReaderBuilder::new().build(file)?;
-            write_in_format(&mut reader, &mut output, format, values)?;
-        }
-    } else {
-        let input: StdinLock = stdin().lock();
-        let mut reader = ReaderBuilder::new().build(input)?;
-        write_in_format(&mut reader, &mut output, format, values)?;
+impl IonCliCommand for DumpCommand {
+    fn name(&self) -> &'static str {
+        "dump"
     }
 
-    output.flush()?;
-    Ok(())
+    fn about(&self) -> &'static str {
+        "Prints Ion in the requested format"
+    }
+
+    fn clap_command(&self) -> Command {
+        Command::new(self.name())
+            .about(self.about())
+            //TODO: Remove `values` after https://github.com/amazon-ion/ion-cli/issues/49
+            .arg(
+                Arg::new("values")
+                    .long("values")
+                    .short('n')
+                    .value_parser(value_parser!(usize))
+                    .allow_negative_numbers(false)
+                    .hide(true)
+                    .help("Specifies the number of output top-level values."),
+            )
+            .arg(
+                Arg::new("format")
+                    .long("format")
+                    .short('f')
+                    .default_value("pretty")
+                    .value_parser(["binary", "text", "pretty", "lines"])
+                    .help("Output format"),
+            )
+            .arg(
+                Arg::new("output")
+                    .long("output")
+                    .short('o')
+                    .help("Output file [default: STDOUT]"),
+            )
+            .arg(
+                // All argv entries after the program name (argv[0])
+                // and any `clap`-managed options are considered input files.
+                Arg::new("input")
+                    .index(1)
+                    .help("Input file [default: STDIN]")
+                    .action(ArgAction::Append)
+                    .trailing_var_arg(true),
+            )
+    }
+
+    fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
+        // --format pretty|text|lines|binary
+        // `clap` validates the specified format and provides a default otherwise.
+        let format = args.get_one::<String>("format").unwrap();
+
+        // --values <n>
+        // this value is supplied when `dump` is invoked as `head`
+        let values: Option<usize> = args.get_one::<usize>("values").copied();
+
+        // -o filename
+        let mut output: Box<dyn Write> = if let Some(output_file) = args.get_one::<String>("output")
+        {
+            let file = File::create(output_file).with_context(|| {
+                format!(
+                    "could not open file output file '{}' for writing",
+                    output_file
+                )
+            })?;
+            Box::new(file)
+        } else {
+            Box::new(stdout().lock())
+        };
+
+        if let Some(input_file_iter) = args.get_many::<String>("input") {
+            for input_file in input_file_iter {
+                let file = File::open(input_file)
+                    .with_context(|| format!("Could not open file '{}'", input_file))?;
+                let mut reader = ReaderBuilder::new().build(file)?;
+                write_in_format(&mut reader, &mut output, format, values)?;
+            }
+        } else {
+            let input: StdinLock = stdin().lock();
+            let mut reader = ReaderBuilder::new().build(input)?;
+            write_in_format(&mut reader, &mut output, format, values)?;
+        }
+
+        output.flush()?;
+        Ok(())
+    }
+}
+
+// TODO: This is a compatibility shim. Several commands refer to dump::run(); that functionality
+//       now lives in `dump`'s implementation of the IonCliCommand trait. These referents should
+//       be updated to refer to functionality in a common module so this can be removed.
+//       See: https://github.com/amazon-ion/ion-cli/issues/49
+pub(crate) fn run(_command: &str, args: &ArgMatches) -> Result<()> {
+    DumpCommand.run(&mut Vec::new(), args)
 }
 
 /// Constructs the appropriate writer for the given format, then writes all values found in the

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -1,6 +1,2 @@
-
-
-
-
 pub mod beta;
 pub mod dump;

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -3,23 +3,38 @@ use clap::{crate_authors, crate_version, Arg, ArgAction, ArgMatches, Command as 
 pub mod beta;
 pub mod dump;
 
+/// Behaviors common to all Ion CLI commands, including both namespaces (groups of commands)
+/// and the commands themselves.
 pub trait IonCliCommand {
+    /// Returns the name of this command.
+    ///
+    /// This value is used for dispatch (that is: mapping the name provided on the command line
+    /// to the appropriate command) and for help messages.
     fn name(&self) -> &'static str;
 
+    /// A brief message describing this command's functionality.
     fn about(&self) -> &'static str;
 
+    /// Initializes a [`ClapCommand`] representing this command and its subcommands (if any).
+    ///
+    /// Commands wishing to customize their `ClapCommand`'s arguments should override
+    /// [`Self::configure_args`].
     fn clap_command(&self) -> ClapCommand {
+        // Create a `ClapCommand` representing each of this command's subcommands.
         let clap_subcommands: Vec<_> = self
             .subcommands()
             .iter()
             .map(|s| s.clap_command())
             .collect();
 
+        // Configure a 'base' clap configuration that has the command's name, about message,
+        // version, and author.
         let mut base_command = ClapCommand::new(self.name())
             .about(self.about())
             .version(crate_version!())
             .author(crate_authors!());
 
+        // If there are subcommands, add them to the configuration and set 'subcommand_required'.
         if !clap_subcommands.is_empty() {
             base_command = base_command
                 .subcommand_required(true)
@@ -36,10 +51,16 @@ pub trait IonCliCommand {
         command
     }
 
+    /// Returns a `Vec` containing all of this command's subcommands.
+    ///
+    /// Namespaces should override the default implementation to specify their subcommands.
+    /// Commands should use the default implementation.
     fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {
         Vec::new()
     }
 
+    /// Returns the subcommand that corresponds to the specified name. If no matching subcommand
+    /// is found, returns `None`.
     fn get_subcommand(&self, subcommand_name: &str) -> Option<Box<dyn IonCliCommand>> {
         let mut subcommands = self.subcommands();
         if let Some(index) = subcommands.iter().position(|s| s.name() == subcommand_name) {
@@ -49,8 +70,12 @@ pub trait IonCliCommand {
         }
     }
 
-    // The default implementation assumes this command is a namespace (i.e. a group of subcommands).
-    // It looks for a subcommand in the arguments, then looks up and runs that subcommand.
+    /// The core logic of the command.
+    ///
+    /// The default implementation assumes this command is a namespace (i.e. a group of subcommands).
+    /// It looks for a subcommand in the arguments, then looks up and runs that subcommand.
+    ///
+    /// Commands should override this implementation.
     fn run(&self, command_path: &mut Vec<String>, args: &ArgMatches) -> anyhow::Result<()> {
         let (subcommand_name, subcommand_args) = args
             .subcommand()
@@ -69,6 +94,8 @@ pub trait IonCliCommand {
     }
 }
 
+/// Extension methods for a [`ClapCommand`] which add flags and options that are common to
+/// commands in the Ion CLI.
 pub trait WithIonCliArgument {
     fn with_input(self) -> Self;
     fn with_output(self) -> Self;

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -1,2 +1,60 @@
+use anyhow::anyhow;
+use clap::{crate_authors, crate_version, ArgMatches, Command as ClapCommand};
 pub mod beta;
 pub mod dump;
+
+pub trait IonCliCommand {
+    fn name(&self) -> &'static str;
+
+    fn about(&self) -> &'static str;
+
+    fn configure_args(&self, _command: &mut ClapCommand) {
+        // Does nothing by default
+    }
+
+    fn clap_command(&self) -> ClapCommand {
+        let clap_subcommands: Vec<_> = self
+            .subcommands()
+            .iter()
+            .map(|s| s.clap_command())
+            .collect();
+        ClapCommand::new(self.name())
+            .about(self.about())
+            .version(crate_version!())
+            .author(crate_authors!())
+            .subcommand_required(true)
+            .subcommands(clap_subcommands)
+    }
+
+    fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {
+        Vec::new()
+    }
+
+    fn get_subcommand(&self, subcommand_name: &str) -> Option<Box<dyn IonCliCommand>> {
+        let mut subcommands = self.subcommands();
+        if let Some(index) = subcommands.iter().position(|s| s.name() == subcommand_name) {
+            Some(subcommands.swap_remove(index))
+        } else {
+            None
+        }
+    }
+
+    // The default implementation assumes this command is a namespace (i.e. a group of subcommands).
+    // It looks for a subcommand in the arguments, then looks up and runs that subcommand.
+    fn run(&self, command_path: &mut Vec<String>, args: &ArgMatches) -> anyhow::Result<()> {
+        let (subcommand_name, subcommand_args) = args
+            .subcommand()
+            .ok_or_else(|| anyhow!("Command '{}' expects a subcommand.", self.name()))?;
+
+        let subcommand = self.get_subcommand(subcommand_name).ok_or_else(|| {
+            anyhow!(
+                "'{}' subcommand '{}' was not recognized.",
+                self.name(),
+                subcommand_name
+            )
+        })?;
+
+        command_path.push(subcommand_name.to_owned());
+        subcommand.run(command_path, subcommand_args)
+    }
+}

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -1,21 +1,6 @@
-use anyhow::Result;
-use clap::{ArgMatches, Command};
+
+
+
+
 pub mod beta;
 pub mod dump;
-
-pub type CommandRunner = fn(&str, &ArgMatches) -> Result<()>;
-
-// Creates a Vec of CLI configurations for all of the available built-in commands
-pub fn built_in_commands() -> Vec<Command> {
-    vec![dump::app(), beta::app()]
-}
-
-// Maps the given command name to the entry point for that command if it exists
-pub fn runner_for_built_in_command(command_name: &str) -> Option<CommandRunner> {
-    let runner = match command_name {
-        "dump" => dump::run,
-        "beta" => beta::run,
-        _ => return None,
-    };
-    Some(runner)
-}

--- a/src/bin/ion/main.rs
+++ b/src/bin/ion/main.rs
@@ -1,8 +1,8 @@
 mod commands;
 
 use crate::commands::beta::BetaNamespace;
-use anyhow::{anyhow, Result};
-use clap::{crate_authors, crate_version, ArgMatches, Command as ClapCommand};
+use anyhow::Result;
+use commands::IonCliCommand;
 
 use crate::commands::dump::DumpCommand;
 
@@ -11,62 +11,6 @@ fn main() -> Result<()> {
     let args = root_command.clap_command().get_matches();
     let mut command_path: Vec<String> = vec![root_command.name().to_owned()];
     root_command.run(&mut command_path, &args)
-}
-
-pub trait IonCliCommand {
-    fn name(&self) -> &'static str;
-
-    fn about(&self) -> &'static str;
-
-    fn configure_args(&self, command: &mut ClapCommand) {
-        // Does nothing by default
-    }
-
-    fn clap_command(&self) -> ClapCommand {
-        let clap_subcommands: Vec<_> = self
-            .subcommands()
-            .iter()
-            .map(|s| s.clap_command())
-            .collect();
-        ClapCommand::new(self.name())
-            .about(self.about())
-            .version(crate_version!())
-            .author(crate_authors!())
-            .subcommand_required(true)
-            .subcommands(clap_subcommands)
-    }
-
-    fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {
-        Vec::new()
-    }
-
-    fn get_subcommand(&self, subcommand_name: &str) -> Option<Box<dyn IonCliCommand>> {
-        let mut subcommands = self.subcommands();
-        if let Some(index) = subcommands.iter().position(|s| s.name() == subcommand_name) {
-            Some(subcommands.swap_remove(index))
-        } else {
-            None
-        }
-    }
-
-    // The default implementation assumes this command is a namespace (i.e. a group of subcommands).
-    // It looks for a subcommand in the arguments, then looks up and runs that subcommand.
-    fn run(&self, command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
-        let (subcommand_name, subcommand_args) = args
-            .subcommand()
-            .ok_or_else(|| anyhow!("Command '{}' expects a subcommand.", self.name()))?;
-
-        let subcommand = self.get_subcommand(subcommand_name).ok_or_else(|| {
-            anyhow!(
-                "'{}' subcommand '{}' was not recognized.",
-                self.name(),
-                subcommand_name
-            )
-        })?;
-
-        command_path.push(subcommand_name.to_owned());
-        subcommand.run(command_path, subcommand_args)
-    }
 }
 
 pub struct RootCommand;

--- a/src/bin/ion/main.rs
+++ b/src/bin/ion/main.rs
@@ -1,34 +1,78 @@
 mod commands;
 
-use crate::commands::{built_in_commands, runner_for_built_in_command};
-use anyhow::Result;
-use clap::{crate_authors, crate_version, Command};
 
-const PROGRAM_NAME: &str = "ion";
+use anyhow::{anyhow, Result};
+use clap::{ArgMatches, Command as ClapCommand, crate_authors, crate_version};
+use crate::commands::beta::BetaNamespace;
+
+use crate::commands::dump::DumpCommand;
 
 fn main() -> Result<()> {
-    let mut app = Command::new(PROGRAM_NAME)
-        .version(crate_version!())
-        .author(crate_authors!())
-        .subcommand_required(true);
+    let root_command = RootCommand;
+    let args = root_command.clap_command().get_matches();
+    let mut command_path: Vec<String> = vec![root_command.name().to_owned()];
+    root_command.run(&mut command_path, &args)
+}
 
-    for command in built_in_commands() {
-        app = app.subcommand(command);
+pub type CommandRunner = fn(&str, &ArgMatches) -> Result<()>;
+
+pub trait IonCliCommand {
+    fn name(&self) -> &'static str;
+
+    fn about(&self) -> &'static str;
+
+    fn clap_command(&self) -> ClapCommand {
+        let clap_subcommands: Vec<_> = self.subcommands().iter().map(|s| s.clap_command()).collect();
+        ClapCommand::new(self.name())
+            .about(self.about())
+            .version(crate_version!())
+            .author(crate_authors!())
+            .subcommand_required(true)
+            .subcommands(clap_subcommands)
     }
 
-    let args = app.get_matches();
-    let (command_name, command_args) = args.subcommand().unwrap();
-
-    if let Some(runner) = runner_for_built_in_command(command_name) {
-        // If a runner is registered for the given command name, command_args is guaranteed to
-        // be defined.
-        runner(command_name, command_args)?;
-    } else {
-        let message = format!(
-            "The requested command ('{}') is not supported and clap did not generate an error message.",
-            command_name
-        );
-        unreachable!("{}", message);
+    fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {
+        Vec::new()
     }
-    Ok(())
+
+    fn get_subcommand(&self, subcommand_name: &str) -> Option<Box<dyn IonCliCommand>> {
+        let mut subcommands = self.subcommands();
+        if let Some(index) = subcommands.iter().position(|s| s.name() == subcommand_name) {
+            Some(subcommands.swap_remove(index))
+        } else {
+            None
+        }
+    }
+
+    // The default implementation assumes this command is a namespace (i.e. a group of subcommands).
+    // It looks for a subcommand in the arguments, then looks up and runs that subcommand.
+    fn run(&self, command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
+        let (subcommand_name, subcommand_args) = args.subcommand()
+            .ok_or_else(|| anyhow!("Command '{}' expects a subcommand.", self.name()))?;
+
+        let subcommand = self.get_subcommand(subcommand_name)
+            .ok_or_else(|| anyhow!("'{}' subcommand '{}' was not recognized.", self.name(), subcommand_name))?;
+
+        command_path.push(subcommand_name.to_owned());
+        subcommand.run(command_path, subcommand_args)
+    }
+}
+
+pub struct RootCommand;
+
+impl IonCliCommand for RootCommand {
+    fn name(&self) -> &'static str {
+        "ion"
+    }
+
+    fn about(&self) -> &'static str {
+        "A collection of tools for working with Ion data."
+    }
+
+    fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {
+        vec![
+            Box::new(BetaNamespace),
+            Box::new(DumpCommand),
+        ]
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -113,7 +113,7 @@ fn run_it<S: AsRef<str>>(
         FileMode::Named => {
             // dump our test data to input file
             let mut input_file = File::create(&input_path)?;
-            input_file.write(ion_text.as_ref().as_bytes())?;
+            input_file.write_all(ion_text.as_ref().as_bytes())?;
             input_file.flush()?;
 
             // TODO: test multiple input files
@@ -171,7 +171,7 @@ fn test_write_all_values(#[case] number: i32, #[case] expected_output: &str) -> 
     let temp_dir = TempDir::new()?;
     let input_path = temp_dir.path().join("test.ion");
     let mut input_file = File::create(&input_path)?;
-    input_file.write(test_data.as_bytes())?;
+    input_file.write_all(test_data.as_bytes())?;
     input_file.flush()?;
     cmd.args([
         "beta",


### PR DESCRIPTION
This PR introduces two traits:

1. `IonCliCommand`, which captures functionality common to all commands/namespaces.
2. `WithIonCliArgument`, which adds extension methods to `clap`'s `Command` type, making it much easier for commands to use the same flag configurations as other commands.

This eliminates a large amount of the copy/pasting that was proliferating across subcommands.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
