### PR TITLE
Adds command to filter user data, leaving symtabs

### DIFF
--- a/src/bin/ion/commands/beta/mod.rs
+++ b/src/bin/ion/commands/beta/mod.rs
@@ -4,6 +4,7 @@ pub mod head;
 pub mod inspect;
 pub mod primitive;
 pub mod schema;
+pub mod symtab;
 pub mod to;
 
 use crate::commands::beta::count::CountCommand;
@@ -12,6 +13,7 @@ use crate::commands::beta::head::HeadCommand;
 use crate::commands::beta::inspect::InspectCommand;
 use crate::commands::beta::primitive::PrimitiveCommand;
 use crate::commands::beta::schema::SchemaNamespace;
+use crate::commands::beta::symtab::SymtabNamespace;
 use crate::commands::beta::to::ToNamespace;
 use crate::commands::IonCliCommand;
 
@@ -35,6 +37,7 @@ impl IonCliCommand for BetaNamespace {
             Box::new(HeadCommand),
             Box::new(FromNamespace),
             Box::new(ToNamespace),
+            Box::new(SymtabNamespace),
         ]
     }
 }

--- a/src/bin/ion/commands/beta/symtab/filter.rs
+++ b/src/bin/ion/commands/beta/symtab/filter.rs
@@ -1,0 +1,88 @@
+use crate::commands::{IonCliCommand, WithIonCliArgument};
+use anyhow::{bail, Context, Result};
+use clap::{ArgMatches, Command};
+use ion_rs::binary::non_blocking::raw_binary_reader::RawBinaryReader;
+use ion_rs::{IonReader, IonResult, IonType, SystemReader, SystemStreamItem};
+use memmap::MmapOptions;
+use std::fs::File;
+use std::io::{stdout, BufWriter, Write};
+
+pub struct SymtabFilterCommand;
+
+impl IonCliCommand for SymtabFilterCommand {
+    fn name(&self) -> &'static str {
+        "filter"
+    }
+
+    fn about(&self) -> &'static str {
+        // XXX Currently only supports binary input
+        "Filters user data out of a binary Ion stream, leaving only the symbol table(s) behind."
+    }
+
+    fn configure_args(&self, command: Command) -> Command {
+        command.with_input().with_output().with_format()
+    }
+
+    fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
+        let mut output: Box<dyn Write> = if let Some(output_file) = args.get_one::<String>("output")
+        {
+            let file = File::create(output_file).with_context(|| {
+                format!(
+                    "could not open file output file '{}' for writing",
+                    output_file
+                )
+            })?;
+            Box::new(BufWriter::new(file))
+        } else {
+            Box::new(stdout().lock())
+        };
+
+        if let Some(input_file_names) = args.get_many::<String>("input") {
+            // Input files were specified, run the converter on each of them in turn
+            for input_file in input_file_names {
+                let file = File::open(input_file.as_str())
+                    .with_context(|| format!("Could not open file '{}'", &input_file))?;
+
+                let mmap = unsafe {
+                    MmapOptions::new()
+                        .map(&file)
+                        .with_context(|| format!("Could not mmap '{}'", input_file))?
+                };
+
+                // Treat the mmap as a byte array.
+                let ion_data: &[u8] = &mmap[..];
+                let raw_reader = RawBinaryReader::new(ion_data);
+                let mut system_reader = SystemReader::new(raw_reader);
+                omit_user_data(ion_data, &mut system_reader, &mut output)?;
+            }
+        } else {
+            bail!("this command does not yet support reading from STDIN")
+        }
+
+        output.flush()?;
+        Ok(())
+    }
+}
+
+pub fn omit_user_data(
+    ion_data: &[u8],
+    reader: &mut SystemReader<RawBinaryReader<&[u8]>>,
+    output: &mut Box<dyn Write>,
+) -> IonResult<()> {
+    loop {
+        match reader.next()? {
+            SystemStreamItem::VersionMarker(major, minor) => {
+                output.write_all(&[0xE0, major, minor, 0xEA])?;
+            }
+            SystemStreamItem::SymbolTableValue(IonType::Struct) => {
+                output.write_all(reader.raw_annotations_bytes().unwrap_or(&[]))?;
+                output.write_all(reader.raw_header_bytes().unwrap())?;
+                let body_range = reader.value_range();
+                let body_bytes = &ion_data[body_range];
+                output.write_all(body_bytes)?;
+            }
+            SystemStreamItem::Nothing => return Ok(()),
+            _ => {}
+        }
+    }
+}

--- a/src/bin/ion/commands/beta/symtab/mod.rs
+++ b/src/bin/ion/commands/beta/symtab/mod.rs
@@ -1,0 +1,20 @@
+use crate::commands::beta::symtab::filter::SymtabFilterCommand;
+use crate::commands::IonCliCommand;
+
+pub mod filter;
+
+pub struct SymtabNamespace;
+
+impl IonCliCommand for SymtabNamespace {
+    fn name(&self) -> &'static str {
+        "symtab"
+    }
+
+    fn about(&self) -> &'static str {
+        "'symtab' is a namespace for commands that operate on symbol tables"
+    }
+
+    fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {
+        vec![Box::new(SymtabFilterCommand)]
+    }
+}


### PR DESCRIPTION
This adds a command (`beta symtab filter`) that strips all user data out of the input stream and writes the remaining symbol tables to output. If you use the `--lift` flag, the symbol tables will be stripped of their `$ion_symbol_table` annotation, lifting them into user-level structs that are easier to view and pipe to other commands downstream.

For the moment, this only supports binary input but that's where symbol tables are most commonly leveraged anyway.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
