### PR TITLE
Adds reusable `for_each_input` method

### DIFF
--- a/src/bin/ion/commands/beta/symtab/filter.rs
+++ b/src/bin/ion/commands/beta/symtab/filter.rs
@@ -1,11 +1,11 @@
-use crate::commands::{IonCliCommand, WithIonCliArgument};
+use crate::commands::{IoSupport, IonCliCommand, WithIonCliArgument};
 use anyhow::{bail, Context, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use ion_rs::binary::non_blocking::raw_binary_reader::RawBinaryReader;
 use ion_rs::{IonReader, IonResult, IonType, SystemReader, SystemStreamItem};
 use memmap::MmapOptions;
 use std::fs::File;
-use std::io::{stdout, BufWriter, Write};
+use std::io::Write;
 
 pub struct SymtabFilterCommand;
 
@@ -32,44 +32,30 @@ impl IonCliCommand for SymtabFilterCommand {
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
-        let mut output: Box<dyn Write> = if let Some(output_file) = args.get_one::<String>("output")
-        {
-            let file = File::create(output_file).with_context(|| {
-                format!(
-                    "could not open file output file '{}' for writing",
-                    output_file
-                )
-            })?;
-            Box::new(BufWriter::new(file))
-        } else {
-            Box::new(stdout().lock())
-        };
-
         let lift_requested = args.get_flag("lift");
 
-        if let Some(input_file_names) = args.get_many::<String>("input") {
-            // Input files were specified, run the converter on each of them in turn
-            for input_file in input_file_names {
-                let file = File::open(input_file.as_str())
-                    .with_context(|| format!("Could not open file '{}'", &input_file))?;
-
-                let mmap = unsafe {
-                    MmapOptions::new()
-                        .map(&file)
-                        .with_context(|| format!("Could not mmap '{}'", input_file))?
-                };
-
-                // Treat the mmap as a byte array.
-                let ion_data: &[u8] = &mmap[..];
-                let raw_reader = RawBinaryReader::new(ion_data);
-                let mut system_reader = SystemReader::new(raw_reader);
-                omit_user_data(ion_data, &mut system_reader, &mut output, lift_requested)?;
+        args.for_each_input(|output, input_file_name| {
+            if input_file_name == "--" {
+                bail!("this command does not yet support reading from STDIN");
             }
-        } else {
-            bail!("this command does not yet support reading from STDIN")
-        }
 
-        output.flush()?;
+            let file = File::open(input_file_name)
+                .with_context(|| format!("Could not open file '{}'", &input_file_name))?;
+
+            let mmap = unsafe {
+                MmapOptions::new()
+                    .map(&file)
+                    .with_context(|| format!("Could not mmap '{}'", input_file_name))?
+            };
+
+            // Treat the mmap as a byte array.
+            let ion_data: &[u8] = &mmap[..];
+            let raw_reader = RawBinaryReader::new(ion_data);
+            let mut system_reader = SystemReader::new(raw_reader);
+            omit_user_data(ion_data, &mut system_reader, output, lift_requested)?;
+            Ok(())
+        })?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
Experimenting with ways to cut down the boilerplate needed to set up IO in each command. While different commands take different approaches to handling input (some `mmap`, some make a `Reader`, some make a `SystemReader`, etc), the handling for output it pretty universal.

This patch shows what the change would look like for the `symtab filter` and `to json` commands.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
