### PR TITLE
Handle BrokenPipe gracefully

### DIFF
--- a/src/bin/ion/main.rs
+++ b/src/bin/ion/main.rs
@@ -3,6 +3,8 @@ mod commands;
 use crate::commands::beta::BetaNamespace;
 use anyhow::Result;
 use commands::IonCliCommand;
+use ion_rs::IonError;
+use std::io::ErrorKind;
 
 use crate::commands::dump::DumpCommand;
 
@@ -10,7 +12,19 @@ fn main() -> Result<()> {
     let root_command = RootCommand;
     let args = root_command.clap_command().get_matches();
     let mut command_path: Vec<String> = vec![root_command.name().to_owned()];
-    root_command.run(&mut command_path, &args)
+
+    if let Err(e) = root_command.run(&mut command_path, &args) {
+        match e.downcast_ref::<IonError>() {
+            // If `ion-cli` is being invoked as part of a pipeline we want to allow the pipeline to
+            // to shut off without printing an error to stderr
+            Some(IonError::IoError { source }) if source.kind() == ErrorKind::BrokenPipe => {
+                return Ok(())
+            }
+            _ => return Err(e),
+        }
+    };
+
+    Ok(())
 }
 
 pub struct RootCommand;


### PR DESCRIPTION
### Description of changes: 
Without this, using `ion-cli` in a pipeline which truncates the output can result in unwanted error output to stderr, e.g.:

```plain
❯ ion dump foo.ion | grep "^  timestamp" | cut -w -f 3 | cut -c 2-20 | head -2
```
```plain
2023-07-31T23:11:36
2023-07-31T23:11:36
Error: Os { code: 32, kind: BrokenPipe, message: "Broken pipe" }

Caused by:
    Broken pipe (os error 32)
```

By handling `BrokenPipe` gracefully (i.e. ignoring it), we instead see:
```plain
❯ ion dump foo.ion | grep "^  timestamp" | cut -w -f 3 | cut -c 2-20 | head -2
```
```plain
2023-07-31T23:11:36
2023-07-31T23:11:36
```
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
