### PR TITLE
dump: autodetect and decompress gzip and zstd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /.idea
 /target
+*.swp
+*.swo
+*.swn

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +170,20 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
+
+[[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
+]
 
 [[package]]
 name = "cfg-if"
@@ -273,6 +293,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -408,6 +437,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -648,6 +687,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb33622da908807a06f9513c19b3c1ad50fab3e4137d82a78107d502075aa199"
+dependencies = [
+ "cfb",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +725,8 @@ dependencies = [
  "clap",
  "colored",
  "convert_case",
+ "flate2",
+ "infer",
  "ion-rs",
  "ion-schema",
  "matches",
@@ -687,6 +737,7 @@ dependencies = [
  "tempfile",
  "tera",
  "thiserror",
+ "zstd",
 ]
 
 [[package]]
@@ -746,6 +797,15 @@ name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -825,6 +885,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "nom"
@@ -998,6 +1067,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "ppv-lite86"
@@ -1459,6 +1534,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "uuid"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,3 +1786,31 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "zstd"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.9+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ keywords = ["format", "parse", "encode"]
 anyhow = "1.0"
 clap = { version = "4.0.17", features = ["cargo"] }
 colored = "2.0.0"
+flate2 = "1.0"
+infer = "0.15.0"
 ion-rs = "0.18.1"
 memmap = "0.7.0"
 tempfile = "3.2.0"
@@ -26,6 +28,7 @@ tera = {  version = "1.18.1", optional = true }
 convert_case = { version = "0.6.0", optional = true }
 matches = "0.1.10"
 thiserror = "1.0.50"
+zstd = "0.13.0"
 
 [dev-dependencies]
 rstest = "~0.17.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.65-slim-buster as builder
+FROM rust:1.75-slim-buster as builder
 WORKDIR /usr/src/ion-cli
 COPY . .
 RUN cargo install --verbose --path .

--- a/src/bin/ion/commands/beta/head.rs
+++ b/src/bin/ion/commands/beta/head.rs
@@ -1,6 +1,6 @@
 use crate::commands::{dump, IonCliCommand, WithIonCliArgument};
 use anyhow::Result;
-use clap::{value_parser, Arg, ArgMatches, Command};
+use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 
 pub struct HeadCommand;
 
@@ -14,15 +14,22 @@ impl IonCliCommand for HeadCommand {
     }
 
     fn configure_args(&self, command: Command) -> Command {
-        command.with_input().with_output().with_format().arg(
-            Arg::new("values")
-                .long("values")
-                .short('n')
-                .value_parser(value_parser!(usize))
-                .allow_negative_numbers(false)
-                .default_value("10")
-                .help("Specifies the number of output top-level values."),
-        )
+        command.with_input().with_output().with_format()
+            .arg(
+                Arg::new("values")
+                    .long("values")
+                    .short('n')
+                    .value_parser(value_parser!(usize))
+                    .allow_negative_numbers(false)
+                    .default_value("10")
+                    .help("Specifies the number of output top-level values."),
+            )
+            .arg(
+                Arg::new("no-auto-decompress")
+                    .long("no-auto-decompress")
+                    .action(ArgAction::SetTrue)
+                    .help("Turn off automatic decompression detection."),
+            )
     }
 
     fn run(&self, command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {

--- a/src/bin/ion/commands/beta/head.rs
+++ b/src/bin/ion/commands/beta/head.rs
@@ -14,7 +14,10 @@ impl IonCliCommand for HeadCommand {
     }
 
     fn configure_args(&self, command: Command) -> Command {
-        command.with_input().with_output().with_format()
+        command
+            .with_input()
+            .with_output()
+            .with_format()
             .arg(
                 Arg::new("values")
                     .long("values")

--- a/src/bin/ion/commands/dump.rs
+++ b/src/bin/ion/commands/dump.rs
@@ -1,11 +1,14 @@
 use crate::commands::{IonCliCommand, WithIonCliArgument};
 use anyhow::{Context, Result};
-use clap::{value_parser, Arg, ArgMatches, Command};
+use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 use ion_rs::*;
 use std::fs::File;
-use std::io::{stdin, stdout, StdinLock, Write};
+use std::io::{stdin, stdout, BufRead, BufReader, Chain, Cursor, Read, StdinLock, Write};
 
 pub struct DumpCommand;
+
+const BUF_READER_CAPACITY: usize = 2 << 20; // 1 MiB
+const INFER_HEADER_LENGTH: usize = 8;
 
 impl IonCliCommand for DumpCommand {
     fn name(&self) -> &'static str {
@@ -31,6 +34,12 @@ impl IonCliCommand for DumpCommand {
             .with_input()
             .with_output()
             .with_format()
+            .arg(
+                Arg::new("no-auto-decompress")
+                    .long("no-auto-decompress")
+                    .action(ArgAction::SetTrue)
+                    .help("Turn off automatic decompression detection."),
+            )
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
@@ -60,12 +69,23 @@ impl IonCliCommand for DumpCommand {
             for input_file in input_file_iter {
                 let file = File::open(input_file)
                     .with_context(|| format!("Could not open file '{}'", input_file))?;
-                let mut reader = ReaderBuilder::new().build(file)?;
+                let mut reader = if let Some(true) = args.get_one::<bool>("no-auto-decompress") {
+                    ReaderBuilder::new().build(file)?
+                } else {
+                    let bfile = BufReader::with_capacity(BUF_READER_CAPACITY, file);
+                    let zfile = auto_decompressing_reader(bfile, INFER_HEADER_LENGTH)?;
+                    ReaderBuilder::new().build(zfile)?
+                };
                 write_in_format(&mut reader, &mut output, format, values)?;
             }
         } else {
             let input: StdinLock = stdin().lock();
-            let mut reader = ReaderBuilder::new().build(input)?;
+            let mut reader = if let Some(true) = args.get_one::<bool>("no-auto-decompress") {
+                ReaderBuilder::new().build(input)?
+            } else {
+                let zinput = auto_decompressing_reader(input, INFER_HEADER_LENGTH)?;
+                ReaderBuilder::new().build(zinput)?
+            };
             write_in_format(&mut reader, &mut output, format, values)?;
         }
 
@@ -215,4 +235,60 @@ fn transcribe_n_values<W: IonWriter>(
     }
     writer.flush()?;
     Ok(index)
+}
+
+/// Autodetects a compressed byte stream and wraps the original reader
+/// into a reader that transparently decompresses.
+///
+/// To support non-seekable readers like `Stdin`, we could have used a
+/// full-blown buffering wrapper with unlimited rewinds, but since we only
+/// need the first few magic bytes at offset 0, we cheat and instead make a
+/// `Chain` reader from the buffered header followed by the original reader.
+///
+/// The choice of `Chain` type here is not quite necessary: it could have
+/// been simply `dyn BufRead`, but there is no `ToIonDataSource` trait
+/// implementation for `dyn BufRead` at the moment.
+type AutoDecompressingReader = Chain<Box<dyn BufRead>, Box<dyn BufRead>>;
+
+fn auto_decompressing_reader<R>(
+    mut reader: R,
+    header_len: usize,
+) -> IonResult<AutoDecompressingReader>
+where
+    R: BufRead + 'static,
+{
+    // read header
+    let mut header_bytes = vec![0; header_len];
+    let nread = reader.read(&mut header_bytes)?;
+    header_bytes.truncate(nread);
+
+    // detect compression type and wrap reader in a decompressor
+    match infer::get(&header_bytes) {
+        Some(t) => match t.extension() {
+            "gz" => {
+                // "rewind" to let the decompressor read magic bytes again
+                let header: Box<dyn BufRead> = Box::new(Cursor::new(header_bytes));
+                let chain = header.chain(reader);
+                let zreader = Box::new(BufReader::new(flate2::read::GzDecoder::new(chain)));
+                // must return a `Chain`, so prepend an empty buffer
+                let nothing: Box<dyn BufRead> = Box::new(Cursor::new(&[] as &[u8]));
+                Ok(nothing.chain(zreader))
+            }
+            "zst" => {
+                let header: Box<dyn BufRead> = Box::new(Cursor::new(header_bytes));
+                let chain = header.chain(reader);
+                let zreader = Box::new(BufReader::new(zstd::stream::read::Decoder::new(chain)?));
+                let nothing: Box<dyn BufRead> = Box::new(Cursor::new(&[] as &[u8]));
+                Ok(nothing.chain(zreader))
+            }
+            _ => {
+                let header: Box<dyn BufRead> = Box::new(Cursor::new(header_bytes));
+                Ok(header.chain(Box::new(reader)))
+            }
+        },
+        None => {
+            let header: Box<dyn BufRead> = Box::new(Cursor::new(header_bytes));
+            Ok(header.chain(Box::new(reader)))
+        }
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -88,7 +88,8 @@ fn run_it<S: AsRef<str>>(
     #[values("", "binary", "text", "pretty")] format_flag: &str,
     #[values(FileMode::Default, FileMode::Named)] input_mode: FileMode,
     #[values(FileMode::Default, FileMode::Named)] output_mode: FileMode,
-    #[values(InputCompress::No, InputCompress::Gz, InputCompress::Zst)] input_compress: InputCompress,
+    #[values(InputCompress::No, InputCompress::Gz, InputCompress::Zst)]
+    input_compress: InputCompress,
 ) -> Result<()> {
     let TestCase {
         ion_text,
@@ -119,16 +120,17 @@ fn run_it<S: AsRef<str>>(
     // prepare input
     let input_bytes = match input_compress {
         InputCompress::Gz => {
-            let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+            let mut encoder =
+                flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
             encoder.write_all(ion_text.as_ref().as_bytes())?;
             encoder.finish()?
-        },
+        }
         InputCompress::Zst => {
             let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), 1)?;
             encoder.write_all(ion_text.as_ref().as_bytes())?;
             encoder.finish()?
-        },
-        _ => ion_text.as_ref().as_bytes().to_vec()
+        }
+        _ => ion_text.as_ref().as_bytes().to_vec(),
     };
 
     match input_mode {


### PR DESCRIPTION
### Issue #, if available:

n/a

### Description of changes:

This change extends the `dump` subcommand to be able to automatically detect gzip- and zstd-compressed Ion files and stdin streams and transparently decompress them. A new option was added, `--no-auto-decompress`, to disable this automatic behavior and decode the original input directly.

Added a new test, `cargo test` passes. No noticeable performance degradation despite some extra dynamic dispatch.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
