### PR TITLE
Modifies `DataModel` and `Language` implementations for code generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "ion-cli"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/src/bin/ion/commands/beta/generate/context.rs
+++ b/src/bin/ion/commands/beta/generate/context.rs
@@ -3,40 +3,43 @@ use std::fmt::{Display, Formatter};
 
 /// Represents a context that will be used for code generation
 pub struct CodeGenContext {
-    // Initially the data_model field is set to None.
-    // Once an ISL type definition is mapped to a data model this will have Some value.
-    pub(crate) data_model: Option<DataModel>,
+    // Initially the abstract_data_type field is set to None.
+    // Once an ISL type definition is mapped to an abstract data type this will have Some value.
+    pub(crate) abstract_data_type: Option<AbstractDataType>,
 }
 
 impl CodeGenContext {
     pub fn new() -> Self {
-        Self { data_model: None }
+        Self {
+            abstract_data_type: None,
+        }
     }
 
-    pub fn with_data_model(&mut self, data_model: DataModel) {
-        self.data_model = Some(data_model);
+    pub fn with_abstract_data_type(&mut self, abstract_data_type: AbstractDataType) {
+        self.abstract_data_type = Some(abstract_data_type);
     }
 }
 
-/// Represents a data model type that can be used to determine which templates can be used for code generation.
+/// Represents an abstract data type type that can be used to determine which templates can be used for code generation.
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub enum DataModel {
-    Value, // a struct with a scalar value (used for `type` constraint)
-    // TODO: Make Sequence parameterized over data type.
-    //  add a data type for sequence here that can be used to read elements for that data type.
-    Sequence, // a struct with a sequence/collection value (used for `element` constraint)
+pub enum AbstractDataType {
+    // a struct with a scalar value (used for `type` constraint)
+    Value,
+    // a struct with a sequence/collection value (used for `element` constraint)
+    // the parameter string represents the data type of the sequence
+    Sequence(String),
     Struct,
 }
 
-impl Display for DataModel {
+impl Display for AbstractDataType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "{}",
             match self {
-                DataModel::Value => "single value struct",
-                DataModel::Sequence => "sequence value struct",
-                DataModel::Struct => "struct",
+                AbstractDataType::Value => "single value struct",
+                AbstractDataType::Sequence(_) => "sequence value struct",
+                AbstractDataType::Struct => "struct",
             }
         )
     }

--- a/src/bin/ion/commands/beta/generate/generator.rs
+++ b/src/bin/ion/commands/beta/generate/generator.rs
@@ -1,6 +1,6 @@
 use crate::commands::beta::generate::context::{AbstractDataType, CodeGenContext};
 use crate::commands::beta::generate::result::{invalid_abstract_data_type_error, CodeGenResult};
-use crate::commands::beta::generate::utils::{Field, Import, Language};
+use crate::commands::beta::generate::utils::{Field, Import, JavaLanguage, Language, RustLanguage};
 use crate::commands::beta::generate::utils::{IonSchemaType, Template};
 use convert_case::{Case, Casing};
 use ion_schema::isl::isl_constraint::{IslConstraint, IslConstraintValue};
@@ -10,42 +10,91 @@ use ion_schema::isl::IslSchema;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
+use std::marker::PhantomData;
 use std::path::Path;
 use tera::{Context, Tera};
 
-// TODO: generator can store language and output path as it doesn't change during code generation process
-pub(crate) struct CodeGenerator<'a> {
+pub(crate) struct CodeGenerator<'a, L: Language> {
     // Represents the templating engine - tera
     // more information: https://docs.rs/tera/latest/tera/
     pub(crate) tera: Tera,
-    language: Language,
     output: &'a Path,
     // Represents a counter for naming anonymous type definitions
     pub(crate) anonymous_type_counter: usize,
+    phantom: PhantomData<L>,
 }
 
-impl<'a> CodeGenerator<'a> {
-    pub fn new(language: Language, output: &'a Path) -> Self {
+impl<'a> CodeGenerator<'a, RustLanguage> {
+    pub fn new(output: &'a Path) -> CodeGenerator<RustLanguage> {
         Self {
-            language,
             output,
             anonymous_type_counter: 0,
             tera: Tera::new("src/bin/ion/commands/beta/generate/templates/**/*.templ").unwrap(),
+            phantom: PhantomData,
         }
     }
 
-    /// Returns true if its a built in type otherwise returns false
-    pub fn is_built_in_type(&self, name: &str) -> bool {
-        match self.language {
-            Language::Rust => {
-                matches!(name, "i64" | "String" | "bool" | "Vec<u8>" | "f64")
-            }
-            Language::Java => {
-                matches!(name, "int" | "String" | "boolean" | "byte[]" | "float")
-            }
+    /// Generates code in Rust for given Ion Schema
+    pub fn generate(&mut self, schema: IslSchema) -> CodeGenResult<()> {
+        // this will be used for Rust to create mod.rs which lists all the generated modules
+        let mut modules = vec![];
+        let mut module_context = tera::Context::new();
+
+        // Register a tera filter that can be used to convert a string to upper camel case
+        self.tera.register_filter("upper_camel", Self::upper_camel);
+        // Register a tera filter that can be used to see if a type is built in data type or not
+        self.tera
+            .register_filter("is_built_in_type", Self::is_built_in_type);
+
+        for isl_type in schema.types() {
+            self.generate_abstract_data_type(&mut modules, isl_type)?;
+        }
+
+        self.generate_modules(&mut modules, &mut module_context)?;
+
+        Ok(())
+    }
+
+    pub fn generate_modules(
+        &mut self,
+        modules: &mut Vec<String>,
+        module_context: &mut Context,
+    ) -> CodeGenResult<()> {
+        module_context.insert("modules", &modules);
+        let rendered = self.tera.render("rust/mod.templ", module_context)?;
+        let mut file = File::create(self.output.join("mod.rs"))?;
+        file.write_all(rendered.as_bytes())?;
+        Ok(())
+    }
+}
+
+impl<'a> CodeGenerator<'a, JavaLanguage> {
+    pub fn new(output: &'a Path) -> CodeGenerator<JavaLanguage> {
+        Self {
+            output,
+            anonymous_type_counter: 0,
+            tera: Tera::new("src/bin/ion/commands/beta/generate/templates/**/*.templ").unwrap(),
+            phantom: PhantomData,
         }
     }
 
+    /// Generates code in Java for given Ion Schema
+    pub fn generate(&mut self, schema: IslSchema) -> CodeGenResult<()> {
+        // this will be used for Rust to create mod.rs which lists all the generated modules
+        let mut modules = vec![];
+
+        // Register a tera filter that can be used to convert a string to upper camel case
+        self.tera.register_filter("upper_camel", Self::upper_camel);
+
+        for isl_type in schema.types() {
+            self.generate_abstract_data_type(&mut modules, isl_type)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a, L: Language> CodeGenerator<'a, L> {
     /// Represents a [tera] filter that converts given tera string value to [upper camel case].
     /// Returns error if the given value is not a string.
     ///
@@ -65,41 +114,31 @@ impl<'a> CodeGenerator<'a> {
         ))
     }
 
-    /// Generates code for given Ion Schema
-    pub fn generate(&mut self, schema: IslSchema) -> CodeGenResult<()> {
-        // this will be used for Rust to create mod.rs which lists all the generated modules
-        let mut modules = vec![];
-        let mut module_context = tera::Context::new();
-
-        // Register a tera filter that can be used to convert a string to upper camel case
-        self.tera.register_filter("upper_camel", Self::upper_camel);
-
-        for isl_type in schema.types() {
-            self.generate_abstract_data_type(&mut modules, isl_type)?;
-        }
-
-        if self.language == Language::Rust {
-            module_context.insert("modules", &modules);
-            let rendered = self.tera.render("rust/mod.templ", &module_context)?;
-            let mut file = File::create(self.output.join("mod.rs"))?;
-            file.write_all(rendered.as_bytes())?;
-        }
-
-        Ok(())
+    /// Represents a [tera] filter that return true if the value is a built in type, otherwise returns false.
+    ///
+    /// For more information: <https://docs.rs/tera/1.19.0/tera/struct.Tera.html#method.register_filter>
+    ///
+    /// [tera]: <https://docs.rs/tera/latest/tera/>
+    pub fn is_built_in_type(
+        value: &tera::Value,
+        _map: &HashMap<String, tera::Value>,
+    ) -> Result<tera::Value, tera::Error> {
+        Ok(tera::Value::Bool(L::is_built_in_type(
+            value
+                .as_str()
+                .ok_or(tera::Error::msg("Required string for this filter"))?,
+        )))
     }
 
-    /// Generates abstract data type based on given ISL type definition
     fn generate_abstract_data_type(
         &mut self,
         modules: &mut Vec<String>,
         isl_type: &IslType,
     ) -> CodeGenResult<()> {
-        let abstract_data_type_name = match isl_type.name().clone() {
-            None => {
-                format!("AnonymousType{}", self.anonymous_type_counter)
-            }
-            Some(name) => name,
-        };
+        let abstract_data_type_name = isl_type
+            .name()
+            .clone()
+            .unwrap_or_else(|| format!("AnonymousType{}", self.anonymous_type_counter));
 
         let mut context = Context::new();
         let mut tera_fields = vec![];
@@ -126,27 +165,95 @@ impl<'a> CodeGenerator<'a> {
         // add imports for the template
         context.insert("imports", &imports);
 
-        // generate read and write APIs for the abstract data type
-        self.generate_read_api(&mut context, &mut tera_fields, &mut code_gen_context)?;
-        self.generate_write_api(&mut context, &mut tera_fields, &mut code_gen_context);
-        modules.push(self.language.file_name(&abstract_data_type_name));
+        // add fields for template
+        if code_gen_context.abstract_data_type == Some(AbstractDataType::Struct)
+            || code_gen_context.abstract_data_type == Some(AbstractDataType::Value)
+            || matches!(
+                code_gen_context.abstract_data_type,
+                Some(AbstractDataType::Sequence(_))
+            )
+        {
+            context.insert("fields", &tera_fields);
+            if let Some(abstract_data_type) = &code_gen_context.abstract_data_type {
+                context.insert("abstract_data_type", abstract_data_type);
+            } else {
+                return invalid_abstract_data_type_error(
+                    "Can not determine abstract data type, constraints are mapping not mapping to an abstract data type.",
+                );
+            }
+        }
+
+        self.render_generated_code(
+            modules,
+            &abstract_data_type_name,
+            &mut context,
+            &mut code_gen_context,
+        )
+    }
+
+    fn render_generated_code(
+        &mut self,
+        modules: &mut Vec<String>,
+        abstract_data_type_name: &str,
+        context: &mut Context,
+        code_gen_context: &mut CodeGenContext,
+    ) -> CodeGenResult<()> {
+        modules.push(L::file_name(abstract_data_type_name));
 
         // Render or generate file for the template with the given context
         let template: &Template = &code_gen_context.abstract_data_type.as_ref().try_into()?;
         let rendered = self
             .tera
             .render(
-                &format!("{}/{}.templ", &self.language, template.name(&self.language)),
-                &context,
+                &format!(
+                    "{}/{}.templ",
+                    L::string_value(),
+                    L::template_as_string(template)
+                ),
+                context,
             )
             .unwrap();
         let mut file = File::create(self.output.join(format!(
             "{}.{}",
-            self.language.file_name(&abstract_data_type_name),
-            self.language.file_extension()
+            L::file_name(abstract_data_type_name),
+            L::file_extension()
         )))?;
         file.write_all(rendered.as_bytes())?;
         Ok(())
+    }
+
+    /// Provides name of the type reference that will be used for generated abstract data type
+    fn type_reference_name(
+        &mut self,
+        isl_type_ref: &IslTypeRef,
+        modules: &mut Vec<String>,
+        imports: &mut Vec<Import>,
+    ) -> CodeGenResult<String> {
+        Ok(match isl_type_ref {
+            IslTypeRef::Named(name, _) => {
+                if !L::is_built_in_type(name) {
+                    imports.push(Import {
+                        module_name: name.to_case(Case::Snake),
+                        type_name: name.to_case(Case::UpperCamel),
+                    });
+                }
+                let schema_type: IonSchemaType = name.into();
+                L::target_type(&schema_type)
+            }
+            IslTypeRef::TypeImport(_, _) => {
+                unimplemented!("Imports in schema are not supported yet!");
+            }
+            IslTypeRef::Anonymous(type_def, _) => {
+                self.anonymous_type_counter += 1;
+                self.generate_abstract_data_type(modules, type_def)?;
+                let name = format!("AnonymousType{}", self.anonymous_type_counter);
+                imports.push(Import {
+                    module_name: name.to_case(Case::Snake),
+                    type_name: name.to_case(Case::UpperCamel),
+                });
+                name
+            }
+        })
     }
 
     /// Maps the given constraint value to an abstract data type
@@ -165,7 +272,11 @@ impl<'a> CodeGenerator<'a> {
                     AbstractDataType::Sequence(type_name.to_owned()),
                     code_gen_context,
                 )?;
-                self.generate_struct_field(tera_fields, type_name, "value", code_gen_context)?;
+                self.generate_struct_field(
+                    tera_fields,
+                    L::target_type_as_sequence(&type_name),
+                    "value",
+                )?;
             }
             IslConstraintValue::Fields(fields, _content_closed) => {
                 self.verify_abstract_data_type_consistency(
@@ -176,7 +287,7 @@ impl<'a> CodeGenerator<'a> {
                     let type_name =
                         self.type_reference_name(value.type_reference(), modules, imports)?;
 
-                    self.generate_struct_field(tera_fields, type_name, name, code_gen_context)?;
+                    self.generate_struct_field(tera_fields, type_name, name)?;
                 }
             }
             IslConstraintValue::Type(isl_type) => {
@@ -186,10 +297,24 @@ impl<'a> CodeGenerator<'a> {
                     AbstractDataType::Value,
                     code_gen_context,
                 )?;
-                self.generate_struct_field(tera_fields, type_name, "value", code_gen_context)?;
+                self.generate_struct_field(tera_fields, type_name, "value")?;
             }
             _ => {}
         }
+        Ok(())
+    }
+
+    /// Generates a struct field based on field name and value(data type)
+    fn generate_struct_field(
+        &mut self,
+        tera_fields: &mut Vec<Field>,
+        abstract_data_type_name: String,
+        field_name: &str,
+    ) -> CodeGenResult<()> {
+        tera_fields.push(Field {
+            name: field_name.to_case(L::field_name_case()),
+            value: abstract_data_type_name,
+        });
         Ok(())
     }
 
@@ -222,239 +347,5 @@ impl<'a> CodeGenerator<'a> {
             code_gen_context.with_abstract_data_type(current_abstract_data_type);
         }
         Ok(())
-    }
-
-    /// Provides name of the type reference that will be used for generated abstract data type
-    fn type_reference_name(
-        &mut self,
-        isl_type_ref: &IslTypeRef,
-        modules: &mut Vec<String>,
-        imports: &mut Vec<Import>,
-    ) -> CodeGenResult<String> {
-        Ok(match isl_type_ref {
-            IslTypeRef::Named(name, _) => {
-                if !self.is_built_in_type(name) {
-                    imports.push(Import {
-                        module_name: name.to_case(Case::Snake),
-                        type_name: name.to_case(Case::UpperCamel),
-                    });
-                }
-                let schema_type: IonSchemaType = name.into();
-                schema_type.target_type(&self.language).to_string()
-            }
-            IslTypeRef::TypeImport(_, _) => {
-                unimplemented!("Imports in schema are not supported yet!");
-            }
-            IslTypeRef::Anonymous(type_def, _) => {
-                self.anonymous_type_counter += 1;
-                self.generate_abstract_data_type(modules, type_def)?;
-                let name = format!("AnonymousType{}", self.anonymous_type_counter);
-                imports.push(Import {
-                    module_name: name.to_case(Case::Snake),
-                    type_name: name.to_case(Case::UpperCamel),
-                });
-                name
-            }
-        })
-    }
-
-    /// Generates a struct field based on field name and value(data type)
-    fn generate_struct_field(
-        &mut self,
-        tera_fields: &mut Vec<Field>,
-        abstraxt_data_type_name: String,
-        field_name: &str,
-        code_gen_context: &mut CodeGenContext,
-    ) -> CodeGenResult<()> {
-        let value = self.generate_field_value(abstraxt_data_type_name, code_gen_context)?;
-
-        tera_fields.push(Field {
-            name: {
-                match self.language {
-                    Language::Rust => field_name.to_case(Case::Snake),
-                    Language::Java => field_name.to_case(Case::Camel),
-                }
-            },
-            value,
-        });
-        Ok(())
-    }
-
-    /// Generates field value in a struct which represents a data type in codegen's programming language
-    fn generate_field_value(
-        &mut self,
-        abstract_data_type_name: String,
-        code_gen_context: &mut CodeGenContext,
-    ) -> CodeGenResult<String> {
-        Ok(self.generate_sequence_field_value(abstract_data_type_name, code_gen_context))
-    }
-
-    /// Generates an appropriately typed sequence in the target programming language to use as a field value
-    pub fn generate_sequence_field_value(
-        &mut self,
-        name: String,
-        code_gen_context: &mut CodeGenContext,
-    ) -> String {
-        if code_gen_context.abstract_data_type == Some(AbstractDataType::Sequence(name.to_owned()))
-        {
-            return match self.language {
-                Language::Rust => {
-                    format!("Vec<{}>", name)
-                }
-                Language::Java => {
-                    format!("ArrayList<{}>", name)
-                }
-            };
-        }
-        name
-    }
-
-    /// Generates Generates a read API for an abstract data type.
-    /// This adds statements for reading each the Ion value(s) that collectively represent the given abstract data type.
-    // TODO: add support for Java
-    fn generate_read_api(
-        &mut self,
-        context: &mut Context,
-        tera_fields: &mut Vec<Field>,
-        code_gen_context: &mut CodeGenContext,
-    ) -> CodeGenResult<()> {
-        let mut read_statements = vec![];
-
-        if code_gen_context.abstract_data_type == Some(AbstractDataType::Struct)
-            || code_gen_context.abstract_data_type == Some(AbstractDataType::Value)
-            || matches!(
-                code_gen_context.abstract_data_type,
-                Some(AbstractDataType::Sequence(_))
-            )
-        {
-            context.insert("fields", &tera_fields);
-            if let Some(abstract_data_type) = &code_gen_context.abstract_data_type {
-                context.insert("abstract_data_type", abstract_data_type);
-            } else {
-                return invalid_abstract_data_type_error(
-                    "Can not determine abstract data type, constraints are mapping not mapping to an abstract data type.",
-                );
-            }
-
-            for tera_field in tera_fields {
-                if !self.is_built_in_type(&tera_field.value) {
-                    if let Some(AbstractDataType::Sequence(sequence_type)) =
-                        &code_gen_context.abstract_data_type
-                    {
-                        read_statements.push(format!(
-                            "\"{}\" => {{ abstract_data_type.{} =",
-                            &tera_field.name, &tera_field.name,
-                        ));
-                        read_statements.push(
-                            r#"{
-                let mut values = vec![];
-                reader.step_in()?;
-                while reader.next()? != StreamItem::Nothing {"#
-                                .to_string(),
-                        );
-                        if !self.is_built_in_type(sequence_type) {
-                            read_statements.push(format!(
-                                "values.push({}::read_from(reader)?)",
-                                sequence_type
-                            ));
-                        } else {
-                            read_statements.push(format!(
-                                "values.push(reader.read_{}()?)",
-                                sequence_type.to_lowercase()
-                            ));
-                        }
-
-                        read_statements.push(
-                            r#"}
-                values }}"#
-                                .to_string(),
-                        );
-                    } else if code_gen_context.abstract_data_type == Some(AbstractDataType::Value) {
-                        context.insert(
-                            "read_statement",
-                            &format!("{}::read_from(reader)?", &tera_field.value,),
-                        );
-                    } else {
-                        read_statements.push(format!(
-                            "\"{}\" => {{ abstract_data_type.{} = {}::read_from(reader)?;}}",
-                            &tera_field.name, &tera_field.name, &tera_field.value,
-                        ));
-                    }
-                } else {
-                    if code_gen_context.abstract_data_type == Some(AbstractDataType::Value) {
-                        context.insert(
-                            "read_statement",
-                            &format!("reader.read_{}()?", &tera_field.value.to_lowercase(),),
-                        );
-                    }
-                    read_statements.push(format!(
-                        "\"{}\" => {{ abstract_data_type.{} = reader.read_{}()?;}}",
-                        &tera_field.name,
-                        &tera_field.name,
-                        &tera_field.value.to_lowercase()
-                    ));
-                }
-            }
-        }
-        context.insert("statements", &read_statements);
-        Ok(())
-    }
-
-    /// Generates write API for an abstract data type
-    /// This adds statements for writing abstract data type as Ion value that will be used by abstract data type templates
-    // TODO: add support for Java
-    fn generate_write_api(
-        &mut self,
-        context: &mut Context,
-        tera_fields: &mut Vec<Field>,
-        code_gen_context: &mut CodeGenContext,
-    ) {
-        let mut write_statements = Vec::new();
-        if code_gen_context.abstract_data_type == Some(AbstractDataType::Value) {
-            for tera_field in tera_fields {
-                if !self.is_built_in_type(&tera_field.value) {
-                    write_statements.push(format!("self.{}.write_to(writer)?;", &tera_field.name,));
-                } else {
-                    write_statements.push(format!(
-                        "writer.write_{}(self.value)?;",
-                        &tera_field.value.to_lowercase(),
-                    ));
-                }
-            }
-        } else if code_gen_context.abstract_data_type == Some(AbstractDataType::Struct) {
-            write_statements.push("writer.step_in(IonType::Struct)?;".to_string());
-            for tera_field in tera_fields {
-                write_statements.push(format!("writer.set_field_name(\"{}\");", &tera_field.name));
-
-                if !self.is_built_in_type(&tera_field.value) {
-                    write_statements.push(format!("self.{}.write_to(writer)?;", &tera_field.name,));
-                } else {
-                    write_statements.push(format!(
-                        "writer.write_{}(self.{})?;",
-                        &tera_field.value.to_lowercase(),
-                        &tera_field.name
-                    ));
-                }
-            }
-            write_statements.push("writer.step_out()?;".to_string());
-        } else if let Some(AbstractDataType::Sequence(sequence_type)) =
-            &code_gen_context.abstract_data_type
-        {
-            write_statements.push("writer.step_in(IonType::List)?;".to_string());
-            for _tera_field in tera_fields {
-                write_statements.push("for value in self.value {".to_string());
-                if !self.is_built_in_type(sequence_type) {
-                    write_statements.push("value.write_to(writer)?;".to_string());
-                } else {
-                    write_statements.push(format!(
-                        "writer.write_{}(value)?;",
-                        &sequence_type.to_lowercase(),
-                    ));
-                }
-                write_statements.push("}".to_string());
-            }
-            write_statements.push("writer.step_out()?;".to_string());
-        }
-        context.insert("write_statements", &write_statements);
     }
 }

--- a/src/bin/ion/commands/beta/generate/generator.rs
+++ b/src/bin/ion/commands/beta/generate/generator.rs
@@ -1,5 +1,5 @@
-use crate::commands::beta::generate::context::{CodeGenContext, DataModel};
-use crate::commands::beta::generate::result::{invalid_data_model_error, CodeGenResult};
+use crate::commands::beta::generate::context::{AbstractDataType, CodeGenContext};
+use crate::commands::beta::generate::result::{invalid_abstract_data_type_error, CodeGenResult};
 use crate::commands::beta::generate::utils::{Field, Import, Language};
 use crate::commands::beta::generate::utils::{IonSchemaType, Template};
 use convert_case::{Case, Casing};
@@ -75,7 +75,7 @@ impl<'a> CodeGenerator<'a> {
         self.tera.register_filter("upper_camel", Self::upper_camel);
 
         for isl_type in schema.types() {
-            self.generate_data_model(&mut modules, isl_type)?;
+            self.generate_abstract_data_type(&mut modules, isl_type)?;
         }
 
         if self.language == Language::Rust {
@@ -88,13 +88,13 @@ impl<'a> CodeGenerator<'a> {
         Ok(())
     }
 
-    /// Generates data model based on given ISL type definition
-    fn generate_data_model(
+    /// Generates abstract data type based on given ISL type definition
+    fn generate_abstract_data_type(
         &mut self,
         modules: &mut Vec<String>,
         isl_type: &IslType,
     ) -> CodeGenResult<()> {
-        let data_model_name = match isl_type.name().clone() {
+        let abstract_data_type_name = match isl_type.name().clone() {
             None => {
                 format!("AnonymousType{}", self.anonymous_type_counter)
             }
@@ -106,15 +106,15 @@ impl<'a> CodeGenerator<'a> {
         let mut imports: Vec<Import> = vec![];
         let mut code_gen_context = CodeGenContext::new();
 
-        // Set the target kind name of the data model (i.e. enum/class)
+        // Set the target kind name of the abstract data type (i.e. enum/class)
         context.insert(
             "target_kind_name",
-            &data_model_name.to_case(Case::UpperCamel),
+            &abstract_data_type_name.to_case(Case::UpperCamel),
         );
 
         let constraints = isl_type.constraints();
         for constraint in constraints {
-            self.map_constraint_to_data_model(
+            self.map_constraint_to_abstract_data_type(
                 modules,
                 &mut tera_fields,
                 &mut imports,
@@ -126,13 +126,13 @@ impl<'a> CodeGenerator<'a> {
         // add imports for the template
         context.insert("imports", &imports);
 
-        // generate read and write APIs for the data model
+        // generate read and write APIs for the abstract data type
         self.generate_read_api(&mut context, &mut tera_fields, &mut code_gen_context)?;
         self.generate_write_api(&mut context, &mut tera_fields, &mut code_gen_context);
-        modules.push(self.language.file_name(&data_model_name));
+        modules.push(self.language.file_name(&abstract_data_type_name));
 
         // Render or generate file for the template with the given context
-        let template: &Template = &code_gen_context.data_model.as_ref().try_into()?;
+        let template: &Template = &code_gen_context.abstract_data_type.as_ref().try_into()?;
         let rendered = self
             .tera
             .render(
@@ -142,15 +142,15 @@ impl<'a> CodeGenerator<'a> {
             .unwrap();
         let mut file = File::create(self.output.join(format!(
             "{}.{}",
-            self.language.file_name(&data_model_name),
+            self.language.file_name(&abstract_data_type_name),
             self.language.file_extension()
         )))?;
         file.write_all(rendered.as_bytes())?;
         Ok(())
     }
 
-    /// Maps the given constraint value to a data model
-    fn map_constraint_to_data_model(
+    /// Maps the given constraint value to an abstract data type
+    fn map_constraint_to_abstract_data_type(
         &mut self,
         modules: &mut Vec<String>,
         tera_fields: &mut Vec<Field>,
@@ -160,48 +160,42 @@ impl<'a> CodeGenerator<'a> {
     ) -> CodeGenResult<()> {
         match constraint.constraint() {
             IslConstraintValue::Element(isl_type, _) => {
-                self.verify_data_model_consistency(DataModel::Sequence, code_gen_context)?;
-                self.generate_struct_field(
-                    tera_fields,
-                    isl_type,
-                    modules,
-                    "value",
-                    imports,
+                let type_name = self.type_reference_name(isl_type, modules, imports)?;
+                self.verify_abstract_data_type_consistency(
+                    AbstractDataType::Sequence(type_name.to_owned()),
                     code_gen_context,
                 )?;
+                self.generate_struct_field(tera_fields, type_name, "value", code_gen_context)?;
             }
             IslConstraintValue::Fields(fields, _content_closed) => {
-                self.verify_data_model_consistency(DataModel::Struct, code_gen_context)?;
+                self.verify_abstract_data_type_consistency(
+                    AbstractDataType::Struct,
+                    code_gen_context,
+                )?;
                 for (name, value) in fields.iter() {
-                    self.generate_struct_field(
-                        tera_fields,
-                        value.type_reference(),
-                        modules,
-                        name,
-                        imports,
-                        code_gen_context,
-                    )?;
+                    let type_name =
+                        self.type_reference_name(value.type_reference(), modules, imports)?;
+
+                    self.generate_struct_field(tera_fields, type_name, name, code_gen_context)?;
                 }
             }
             IslConstraintValue::Type(isl_type) => {
-                self.verify_data_model_consistency(DataModel::Value, code_gen_context)?;
-                self.generate_struct_field(
-                    tera_fields,
-                    isl_type,
-                    modules,
-                    "value",
-                    imports,
+                let type_name = self.type_reference_name(isl_type, modules, imports)?;
+
+                self.verify_abstract_data_type_consistency(
+                    AbstractDataType::Value,
                     code_gen_context,
                 )?;
+                self.generate_struct_field(tera_fields, type_name, "value", code_gen_context)?;
             }
             _ => {}
         }
         Ok(())
     }
 
-    /// Verify that the current data model is same as previously determined data model
-    /// This is referring to data model determined with each constraint that is verifies
-    /// that all the constraints map to a single data model and not different data models.
+    /// Verify that the current abstract data type is same as previously determined abstract data type
+    /// This is referring to abstract data type determined with each constraint that is verifies
+    /// that all the constraints map to a single abstract data type and not different abstract data types.
     /// e.g.
     /// ```
     /// type::{
@@ -213,34 +207,66 @@ impl<'a> CodeGenerator<'a> {
     ///   }
     /// }
     /// ```
-    /// For the above schema, both `fields` and `type` constraints map to different data models
+    /// For the above schema, both `fields` and `type` constraints map to different abstract data types
     /// respectively Struct(with given fields `source` and `destination`) and Value(with a single field that has String data type).
-    fn verify_data_model_consistency(
+    fn verify_abstract_data_type_consistency(
         &mut self,
-        current_data_model: DataModel,
+        current_abstract_data_type: AbstractDataType,
         code_gen_context: &mut CodeGenContext,
     ) -> CodeGenResult<()> {
-        if let Some(data_model) = &code_gen_context.data_model {
-            if data_model != &current_data_model {
-                return invalid_data_model_error(format!("Can not determine abstract data type as current constraint {} conflicts with prior constraints for {}.", current_data_model, data_model));
+        if let Some(abstract_data_type) = &code_gen_context.abstract_data_type {
+            if abstract_data_type != &current_abstract_data_type {
+                return invalid_abstract_data_type_error(format!("Can not determine abstract data type as current constraint {} conflicts with prior constraints for {}.", current_abstract_data_type, abstract_data_type));
             }
         } else {
-            code_gen_context.with_data_model(current_data_model);
+            code_gen_context.with_abstract_data_type(current_abstract_data_type);
         }
         Ok(())
+    }
+
+    /// Provides name of the type reference that will be used for generated abstract data type
+    fn type_reference_name(
+        &mut self,
+        isl_type_ref: &IslTypeRef,
+        modules: &mut Vec<String>,
+        imports: &mut Vec<Import>,
+    ) -> CodeGenResult<String> {
+        Ok(match isl_type_ref {
+            IslTypeRef::Named(name, _) => {
+                if !self.is_built_in_type(name) {
+                    imports.push(Import {
+                        module_name: name.to_case(Case::Snake),
+                        type_name: name.to_case(Case::UpperCamel),
+                    });
+                }
+                let schema_type: IonSchemaType = name.into();
+                schema_type.target_type(&self.language).to_string()
+            }
+            IslTypeRef::TypeImport(_, _) => {
+                unimplemented!("Imports in schema are not supported yet!");
+            }
+            IslTypeRef::Anonymous(type_def, _) => {
+                self.anonymous_type_counter += 1;
+                self.generate_abstract_data_type(modules, type_def)?;
+                let name = format!("AnonymousType{}", self.anonymous_type_counter);
+                imports.push(Import {
+                    module_name: name.to_case(Case::Snake),
+                    type_name: name.to_case(Case::UpperCamel),
+                });
+                name
+            }
+        })
     }
 
     /// Generates a struct field based on field name and value(data type)
     fn generate_struct_field(
         &mut self,
         tera_fields: &mut Vec<Field>,
-        isl_type_ref: &IslTypeRef,
-        modules: &mut Vec<String>,
+        abstraxt_data_type_name: String,
         field_name: &str,
-        imports: &mut Vec<Import>,
         code_gen_context: &mut CodeGenContext,
     ) -> CodeGenResult<()> {
-        let value = self.generate_field_value(isl_type_ref, modules, imports, code_gen_context)?;
+        let value = self.generate_field_value(abstraxt_data_type_name, code_gen_context)?;
 
         tera_fields.push(Field {
             name: {
@@ -257,39 +283,10 @@ impl<'a> CodeGenerator<'a> {
     /// Generates field value in a struct which represents a data type in codegen's programming language
     fn generate_field_value(
         &mut self,
-        isl_type_ref: &IslTypeRef,
-        modules: &mut Vec<String>,
-        imports: &mut Vec<Import>,
+        abstract_data_type_name: String,
         code_gen_context: &mut CodeGenContext,
     ) -> CodeGenResult<String> {
-        Ok(match isl_type_ref {
-            IslTypeRef::Named(name, _) => {
-                if !self.is_built_in_type(name) {
-                    imports.push(Import {
-                        module_name: name.to_case(Case::Snake),
-                        type_name: name.to_case(Case::UpperCamel),
-                    });
-                }
-                let schema_type: IonSchemaType = name.into();
-                self.generate_sequence_field_value(
-                    schema_type.target_type(&self.language).to_string(),
-                    code_gen_context,
-                )
-            }
-            IslTypeRef::TypeImport(_, _) => {
-                unimplemented!("Imports in schema are not supported yet!");
-            }
-            IslTypeRef::Anonymous(type_def, _) => {
-                self.anonymous_type_counter += 1;
-                self.generate_data_model(modules, type_def)?;
-                let name = format!("AnonymousType{}", self.anonymous_type_counter);
-                imports.push(Import {
-                    module_name: name.to_case(Case::Snake),
-                    type_name: name.to_case(Case::UpperCamel),
-                });
-                self.generate_sequence_field_value(name, code_gen_context)
-            }
-        })
+        Ok(self.generate_sequence_field_value(abstract_data_type_name, code_gen_context))
     }
 
     /// Generates an appropriately typed sequence in the target programming language to use as a field value
@@ -298,7 +295,8 @@ impl<'a> CodeGenerator<'a> {
         name: String,
         code_gen_context: &mut CodeGenContext,
     ) -> String {
-        if code_gen_context.data_model == Some(DataModel::Sequence) {
+        if code_gen_context.abstract_data_type == Some(AbstractDataType::Sequence(name.to_owned()))
+        {
             return match self.language {
                 Language::Rust => {
                     format!("Vec<{}>", name)
@@ -322,24 +320,29 @@ impl<'a> CodeGenerator<'a> {
     ) -> CodeGenResult<()> {
         let mut read_statements = vec![];
 
-        if code_gen_context.data_model == Some(DataModel::Struct)
-            || code_gen_context.data_model == Some(DataModel::Value)
-            || code_gen_context.data_model == Some(DataModel::Sequence)
+        if code_gen_context.abstract_data_type == Some(AbstractDataType::Struct)
+            || code_gen_context.abstract_data_type == Some(AbstractDataType::Value)
+            || matches!(
+                code_gen_context.abstract_data_type,
+                Some(AbstractDataType::Sequence(_))
+            )
         {
             context.insert("fields", &tera_fields);
-            if let Some(data_model) = &code_gen_context.data_model {
-                context.insert("data_model", data_model);
+            if let Some(abstract_data_type) = &code_gen_context.abstract_data_type {
+                context.insert("abstract_data_type", abstract_data_type);
             } else {
-                return invalid_data_model_error(
-                    "Can not determine data model, constraints are mapping not mapping to a data model.",
+                return invalid_abstract_data_type_error(
+                    "Can not determine abstract data type, constraints are mapping not mapping to an abstract data type.",
                 );
             }
 
             for tera_field in tera_fields {
                 if !self.is_built_in_type(&tera_field.value) {
-                    if code_gen_context.data_model == Some(DataModel::Sequence) {
+                    if let Some(AbstractDataType::Sequence(sequence_type)) =
+                        &code_gen_context.abstract_data_type
+                    {
                         read_statements.push(format!(
-                            "\"{}\" => {{ data_model.{} =",
+                            "\"{}\" => {{ abstract_data_type.{} =",
                             &tera_field.name, &tera_field.name,
                         ));
                         read_statements.push(
@@ -349,7 +352,6 @@ impl<'a> CodeGenerator<'a> {
                 while reader.next()? != StreamItem::Nothing {"#
                                 .to_string(),
                         );
-                        let sequence_type = &tera_field.value.replace("Vec<", "").replace('>', "");
                         if !self.is_built_in_type(sequence_type) {
                             read_statements.push(format!(
                                 "values.push({}::read_from(reader)?)",
@@ -367,26 +369,26 @@ impl<'a> CodeGenerator<'a> {
                 values }}"#
                                 .to_string(),
                         );
-                    } else if code_gen_context.data_model == Some(DataModel::Value) {
+                    } else if code_gen_context.abstract_data_type == Some(AbstractDataType::Value) {
                         context.insert(
                             "read_statement",
                             &format!("{}::read_from(reader)?", &tera_field.value,),
                         );
                     } else {
                         read_statements.push(format!(
-                            "\"{}\" => {{ data_model.{} = {}::read_from(reader)?;}}",
+                            "\"{}\" => {{ abstract_data_type.{} = {}::read_from(reader)?;}}",
                             &tera_field.name, &tera_field.name, &tera_field.value,
                         ));
                     }
                 } else {
-                    if code_gen_context.data_model == Some(DataModel::Value) {
+                    if code_gen_context.abstract_data_type == Some(AbstractDataType::Value) {
                         context.insert(
                             "read_statement",
                             &format!("reader.read_{}()?", &tera_field.value.to_lowercase(),),
                         );
                     }
                     read_statements.push(format!(
-                        "\"{}\" => {{ data_model.{} = reader.read_{}()?;}}",
+                        "\"{}\" => {{ abstract_data_type.{} = reader.read_{}()?;}}",
                         &tera_field.name,
                         &tera_field.name,
                         &tera_field.value.to_lowercase()
@@ -398,8 +400,8 @@ impl<'a> CodeGenerator<'a> {
         Ok(())
     }
 
-    /// Generates write API for a data model
-    /// This adds statements for writing data model as Ion value that will be used by data model templates
+    /// Generates write API for an abstract data type
+    /// This adds statements for writing abstract data type as Ion value that will be used by abstract data type templates
     // TODO: add support for Java
     fn generate_write_api(
         &mut self,
@@ -408,7 +410,7 @@ impl<'a> CodeGenerator<'a> {
         code_gen_context: &mut CodeGenContext,
     ) {
         let mut write_statements = Vec::new();
-        if code_gen_context.data_model == Some(DataModel::Value) {
+        if code_gen_context.abstract_data_type == Some(AbstractDataType::Value) {
             for tera_field in tera_fields {
                 if !self.is_built_in_type(&tera_field.value) {
                     write_statements.push(format!("self.{}.write_to(writer)?;", &tera_field.name,));
@@ -419,7 +421,7 @@ impl<'a> CodeGenerator<'a> {
                     ));
                 }
             }
-        } else if code_gen_context.data_model == Some(DataModel::Struct) {
+        } else if code_gen_context.abstract_data_type == Some(AbstractDataType::Struct) {
             write_statements.push("writer.step_in(IonType::Struct)?;".to_string());
             for tera_field in tera_fields {
                 write_statements.push(format!("writer.set_field_name(\"{}\");", &tera_field.name));
@@ -435,10 +437,11 @@ impl<'a> CodeGenerator<'a> {
                 }
             }
             write_statements.push("writer.step_out()?;".to_string());
-        } else if code_gen_context.data_model == Some(DataModel::Sequence) {
+        } else if let Some(AbstractDataType::Sequence(sequence_type)) =
+            &code_gen_context.abstract_data_type
+        {
             write_statements.push("writer.step_in(IonType::List)?;".to_string());
-            for tera_field in tera_fields {
-                let sequence_type = &tera_field.value.replace("Vec<", "").replace('>', "");
+            for _tera_field in tera_fields {
                 write_statements.push("for value in self.value {".to_string());
                 if !self.is_built_in_type(sequence_type) {
                     write_statements.push("value.write_to(writer)?;".to_string());

--- a/src/bin/ion/commands/beta/generate/mod.rs
+++ b/src/bin/ion/commands/beta/generate/mod.rs
@@ -4,15 +4,14 @@ mod result;
 mod utils;
 
 use crate::commands::beta::generate::generator::CodeGenerator;
-use crate::commands::beta::generate::utils::Language;
+use crate::commands::beta::generate::utils::{JavaLanguage, RustLanguage};
 use crate::commands::IonCliCommand;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use ion_schema::authority::{DocumentAuthority, FileSystemDocumentAuthority};
 use ion_schema::system::SchemaSystem;
 use std::fs;
 use std::path::{Path, PathBuf};
-
 pub struct GenerateCommand;
 
 impl IonCliCommand for GenerateCommand {
@@ -62,7 +61,7 @@ impl IonCliCommand for GenerateCommand {
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
         // Extract programming language for code generation
-        let language: Language = args.get_one::<String>("language").unwrap().as_str().into();
+        let language: &str = args.get_one::<String>("language").unwrap().as_str();
 
         // Extract output path information where the generated code will be saved
         // Create a module `ion_data_model` for storing all the generated code in the output directory
@@ -102,7 +101,14 @@ impl IonCliCommand for GenerateCommand {
         println!("Started generating code...");
 
         // generate code based on schema and programming language
-        CodeGenerator::new(language, output).generate(schema)?;
+        match language {
+            "java" => CodeGenerator::<JavaLanguage>::new(output).generate(schema)?,
+            "rust" => CodeGenerator::<RustLanguage>::new(output).generate(schema)?,
+            _ => bail!(
+                "Unsupported programming language: {}, this tool only supports Java and Rust code generation.",
+                language
+            )
+        }
 
         println!("Code generation complete successfully!");
         println!("Path to generated code: {}", output.display());

--- a/src/bin/ion/commands/beta/generate/result.rs
+++ b/src/bin/ion/commands/beta/generate/result.rs
@@ -28,7 +28,7 @@ pub enum CodeGenError {
 
 /// A convenience method for creating an CodeGen containing an CodeGenError::InvalidDataModel
 /// with the provided description text.
-pub fn invalid_data_model_error<T, S: AsRef<str>>(description: S) -> CodeGenResult<T> {
+pub fn invalid_abstract_data_type_error<T, S: AsRef<str>>(description: S) -> CodeGenResult<T> {
     Err(CodeGenError::InvalidDataModel {
         description: description.as_ref().to_string(),
     })

--- a/src/bin/ion/commands/beta/generate/templates/rust/struct.templ
+++ b/src/bin/ion/commands/beta/generate/templates/rust/struct.templ
@@ -25,22 +25,44 @@ impl {{ target_kind_name }} {
     }
     {% endfor %}
 
-    {% if statements %}
+
     pub fn read_from(reader: &mut Reader) -> IonResult<Self> {
         reader.next()?;
-        {% if abstract_data_type == "UnitStruct"%}
+        {% if abstract_data_type == "Value"%}
             let mut abstract_data_type = {{ target_kind_name }}::default();
-            abstract_data_type.value = {{ read_statement }};
+            abstract_data_type.value = {% if target_kind_name | is_built_in_type == false %}
+                                            {{ target_kind_name }}::read_from(reader)?;
+                                        {% else %}
+                                            reader.read_{{ target_kind_name }}()?;
+                                        {% endif %}
         {% else %}
             {% if abstract_data_type == "Struct"%}reader.step_in()?;{% endif %}
             let mut abstract_data_type = {{ target_kind_name }}::default();
             while reader.next()? != StreamItem::Nothing {
                 if let Some(field_name) = reader.field_name()?.text() {
                     match field_name {
-
-                     {% for statement in statements -%}
-                            {{ statement }}
-                     {% endfor %}
+                        {% for field in fields -%}
+                            {% if field.value | is_built_in_type == false %}
+                                {% if abstract_data_type is object and abstract_data_type["Sequence"] | length != 0 %}
+                                 "{{ field.name }}" => { abstract_data_type.{{ field.name }} = {
+                                     let mut values = vec![];
+                                     reader.step_in()?;
+                                     while reader.next()? != StreamItem::Nothing {
+                                        {% if abstract_data_type["Sequence"] | is_built_in_type == false %}
+                                            values.push({{ abstract_data_type["Sequence"] }}::read_from(reader)?);
+                                        {% else %}
+                                            values.push(reader.read_{{ abstract_data_type["Sequence"] }}()?);
+                                        {% endif %}
+                                    }
+                                    values
+                                 };}
+                                 {% elif abstract_data_type == "Struct" %}
+                                 "{{ field.name }}" => { abstract_data_type.{{ field.name }} = {{ field.value }}::read_from(reader)?; }
+                                 {% endif %}
+                            {% else %}
+                            "{{ field.name }}" => { abstract_data_type.{{ field.name }} = reader.read_{{ field.value }}()?; }
+                            {% endif %}
+                        {% endfor %}
                      _ => {}
                     }
                 }
@@ -49,12 +71,38 @@ impl {{ target_kind_name }} {
         {% endif %}
      Ok(abstract_data_type)
     }
-    {% endif %}
 
     pub fn write_to<W: IonWriter>(&self, writer: &mut W) -> IonResult<()> {
-        {% for statement in write_statements -%}
-           {{ statement }}
-        {% endfor %}
+        {% if abstract_data_type == "Value" %}
+            {% for field in fields %}
+                {% if field.value | is_built_in_type ==false  %}
+                    self.{{ field.name }}.write_to(writer)?;
+                {% else %}
+                    writer.write_{{ field.value | lower }}(self.value)?;
+                {% endif %}
+            {% endfor %}
+        {% elif abstract_data_type == "Struct"%}
+            writer.step_in(IonType::Struct)?;
+            {% for field in fields %}
+            writer.set_field_name("{{ field.name }}");
+                {% if field.value | is_built_in_type == false %}
+                    self.{{ field.name }}.write_to(writer)?;
+                {% else %}
+                    writer.write_{{ field.value | lower }}(self.{{ field.name }})?;
+                {% endif %}
+            {% endfor %}
+            writer.step_out()?;
+        {% elif abstract_data_type is object and abstract_data_type["Sequence"] | length != 0 %}
+            writer.step_in(IonType::List)?;
+            for value in self.value {
+                {% if abstract_data_type["Sequence"] | is_built_in_type  == false %}
+                    value.write_to(writer)?;
+                {% else %}
+                   writer.write_{{ abstract_data_type["Sequence"] | lower }}(value)?;
+                {% endif %}
+            }
+            writer.step_out()?;
+        {% endif %}
         Ok(())
     }
 }

--- a/src/bin/ion/commands/beta/generate/templates/rust/struct.templ
+++ b/src/bin/ion/commands/beta/generate/templates/rust/struct.templ
@@ -28,12 +28,12 @@ impl {{ target_kind_name }} {
     {% if statements %}
     pub fn read_from(reader: &mut Reader) -> IonResult<Self> {
         reader.next()?;
-        {% if data_model == "UnitStruct"%}
-            let mut data_model = {{ target_kind_name }}::default();
-            data_model.value = {{ read_statement }};
+        {% if abstract_data_type == "UnitStruct"%}
+            let mut abstract_data_type = {{ target_kind_name }}::default();
+            abstract_data_type.value = {{ read_statement }};
         {% else %}
-            {% if data_model == "Struct"%}reader.step_in()?;{% endif %}
-            let mut data_model = {{ target_kind_name }}::default();
+            {% if abstract_data_type == "Struct"%}reader.step_in()?;{% endif %}
+            let mut abstract_data_type = {{ target_kind_name }}::default();
             while reader.next()? != StreamItem::Nothing {
                 if let Some(field_name) = reader.field_name()?.text() {
                     match field_name {
@@ -45,9 +45,9 @@ impl {{ target_kind_name }} {
                     }
                 }
             }
-            {% if data_model == "Struct"%}reader.step_out()?;{% endif %}
+            {% if abstract_data_type == "Struct"%}reader.step_out()?;{% endif %}
         {% endif %}
-     Ok(data_model)
+     Ok(abstract_data_type)
     }
     {% endif %}
 

--- a/src/bin/ion/commands/beta/generate/utils.rs
+++ b/src/bin/ion/commands/beta/generate/utils.rs
@@ -1,5 +1,5 @@
-use crate::commands::beta::generate::context::DataModel;
-use crate::commands::beta::generate::result::{invalid_data_model_error, CodeGenError};
+use crate::commands::beta::generate::context::AbstractDataType;
+use crate::commands::beta::generate::result::{invalid_abstract_data_type_error, CodeGenError};
 use convert_case::{Case, Casing};
 use serde::Serialize;
 use std::fmt::{Display, Formatter};
@@ -86,15 +86,15 @@ impl Template {
     }
 }
 
-impl TryFrom<Option<&DataModel>> for Template {
+impl TryFrom<Option<&AbstractDataType>> for Template {
     type Error = CodeGenError;
 
-    fn try_from(value: Option<&DataModel>) -> Result<Self, Self::Error> {
+    fn try_from(value: Option<&AbstractDataType>) -> Result<Self, Self::Error> {
         match value {
-            Some(DataModel::Value) | Some(DataModel::Sequence) | Some(DataModel::Struct) => {
-                Ok(Template::Struct)
-            }
-            None => invalid_data_model_error(
+            Some(AbstractDataType::Value)
+            | Some(AbstractDataType::Sequence(_))
+            | Some(AbstractDataType::Struct) => Ok(Template::Struct),
+            None => invalid_abstract_data_type_error(
                 "Can not get a template without determining data model first.",
             ),
         }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -297,7 +297,7 @@ fn test_code_generation_in_rust(
     let mut cmd = Command::cargo_bin("ion")?;
     let temp_dir = TempDir::new()?;
     let input_schema_path = temp_dir.path().join("test_schema.isl");
-    let mut input_schema_file = File::create(&input_schema_path)?;
+    let mut input_schema_file = File::create(input_schema_path)?;
     input_schema_file.write(test_schema.as_bytes())?;
     input_schema_file.flush()?;
     cmd.args([
@@ -412,7 +412,7 @@ fn test_code_generation_in_java(
     let mut cmd = Command::cargo_bin("ion")?;
     let temp_dir = TempDir::new()?;
     let input_schema_path = temp_dir.path().join("test_schema.isl");
-    let mut input_schema_file = File::create(&input_schema_path)?;
+    let mut input_schema_file = File::create(input_schema_path)?;
     input_schema_file.write(test_schema.as_bytes())?;
     input_schema_file.flush()?;
     cmd.args([


### PR DESCRIPTION
### Issue #76, #71, #69

### Description of changes:
This PR works on modifying `DataModel` and `Language` implementations for code generator.

### List of changes:
* Modifies definition of `DataModel`
  * Renames `DataModel` to `AbstractDataType`
  * Adds parameter to `Sequence` enum variant to store data type information for the sequence
* Adds Language trait for generator
  * Adds `Language` as trait insatead of enum
  * Adds `RustLanguage` and `JavaLanguage` as implementations of
  `Language`
  * Uses `Language` trait as generic for `CodeGenerator`
  * Moves read and write API generation code to templates
  * Reorganizes `CodeGenerator` to keep common behavior between languages
  in `CodeGenerator<L>`
  * Moves Rust related generation cod e in `CodeGenerator<Rust>`
  * Moves Java related generation cod e in `CodeGenerator<Java>`

### Test
Tests for code generation in Rust and Java
(Note: This PR only includes reorganization and renaming changes)

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
