### PR TITLE
Directs output of 'inspect' to a pager (default: 'less').

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ matches = "0.1.10"
 thiserror = "1.0.50"
 zstd = "0.13.0"
 
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+pager = "0.16.1"
+
 [dev-dependencies]
 rstest = "~0.17.0"
 assert_cmd = "~1.0.5"

--- a/src/bin/ion/commands/beta/inspect.rs
+++ b/src/bin/ion/commands/beta/inspect.rs
@@ -12,6 +12,8 @@ use clap::{Arg, ArgMatches, Command};
 use colored::Colorize;
 use ion_rs::*;
 use memmap::MmapOptions;
+#[cfg(not(target_os = "windows"))]
+use pager::Pager;
 
 pub struct InspectCommand;
 
@@ -62,7 +64,17 @@ complete value will be displayed.",
             )
     }
 
+    #[cfg(not(target_os = "windows"))] // TODO find a cross-platform pager implementation.
+    fn set_up_pager(&self) {
+        // Direct output to the pager specified by the PAGER environment variable, or "less -FIRX"
+        // if the environment variable is not set. Note: a pager is not used if the output is not
+        // a TTY.
+        Pager::with_default_pager("less -FIRX").setup();
+    }
+
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
+        self.set_up_pager();
+
         // --skip-bytes has a default value, so we can unwrap this safely.
         let skip_bytes_arg = args.get_one::<String>("skip-bytes").unwrap().as_str();
 

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -70,6 +70,10 @@ pub trait IonCliCommand {
         }
     }
 
+    /// Sets up the pager (e.g. `less`)  to which long text output will be directed. The default
+    /// implementation does not configure a pager.
+    fn set_up_pager(&self) {}
+
     /// The core logic of the command.
     ///
     /// The default implementation assumes this command is a namespace (i.e. a group of subcommands).


### PR DESCRIPTION
### Description of changes:

Inspired by the CLI Guidelines (https://clig.dev/#output); also, I always pipe `ion beta inspect` to less, but usually after I've forgotten to do that and blown away my terminal by trying to inspect a huge file.

This PR directs output to the pager specified by the `PAGER` environment variable, or `less -FIRX` if the environment variable is not set. Note: a pager is not used if the output is not a TTY.

`less -FIRX` has the following behavior:
* does not page if the content fills one screen (i.e., for small streams, the behavior does not change)
* ignores case when you search
* enables color and formatting (which we don't currently use, but could)
* leaves the contents on the screen when `less` quits

Currently a pager is not used on Windows because the [`pager`](https://docs.rs/pager/latest/pager/) crate appears to be Unix-only. It looks like there may be some pure Rust pager implementations that we could probably use instead. I liked this one because it allows users to bring their own pager. Before going deeper into this I wanted to open this PR for discussion.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
