### PR TITLE
Adds changes for setting up integration roundtrip tests for generated code

### DIFF
--- a/src/bin/ion/commands/beta/generate/generator.rs
+++ b/src/bin/ion/commands/beta/generate/generator.rs
@@ -113,7 +113,7 @@ impl<'a> CodeGenerator<'a, RustLanguage> {
 }
 
 impl<'a> CodeGenerator<'a, JavaLanguage> {
-    pub fn new(output: &'a Path) -> CodeGenerator<JavaLanguage> {
+    pub fn new(output: &'a Path, namespace: &str) -> CodeGenerator<JavaLanguage> {
         let tera = Tera::new(&format!(
             "{}/src/bin/ion/commands/beta/generate/templates/java/*.templ",
             env!("CARGO_MANIFEST_DIR")

--- a/src/bin/ion/commands/beta/generate/generator.rs
+++ b/src/bin/ion/commands/beta/generate/generator.rs
@@ -29,7 +29,11 @@ impl<'a> CodeGenerator<'a, RustLanguage> {
         Self {
             output,
             anonymous_type_counter: 0,
-            tera: Tera::new("src/bin/ion/commands/beta/generate/templates/rust/*.templ").unwrap(),
+            tera: Tera::new(&format!(
+                "{}/src/bin/ion/commands/beta/generate/templates/rust/*.templ",
+                env!("CARGO_MANIFEST_DIR")
+            ))
+            .unwrap(),
             phantom: PhantomData,
         }
     }
@@ -78,7 +82,11 @@ impl<'a> CodeGenerator<'a, JavaLanguage> {
         Self {
             output,
             anonymous_type_counter: 0,
-            tera: Tera::new("src/bin/ion/commands/beta/generate/templates/java/*.templ").unwrap(),
+            tera: Tera::new(&format!(
+                "{}/src/bin/ion/commands/beta/generate/templates/java/*.templ",
+                env!("CARGO_MANIFEST_DIR")
+            ))
+            .unwrap(),
             phantom: PhantomData,
         }
     }
@@ -302,6 +310,7 @@ impl<'a, L: Language> CodeGenerator<'a, L> {
                 self.generate_struct_field(
                     tera_fields,
                     L::target_type_as_sequence(&type_name),
+                    isl_type.name(),
                     "value",
                 )?;
             }
@@ -315,7 +324,12 @@ impl<'a, L: Language> CodeGenerator<'a, L> {
                     let type_name =
                         self.type_reference_name(value.type_reference(), modules, imports)?;
 
-                    self.generate_struct_field(tera_fields, type_name, name)?;
+                    self.generate_struct_field(
+                        tera_fields,
+                        type_name,
+                        value.type_reference().name(),
+                        name,
+                    )?;
                 }
             }
             IslConstraintValue::Type(isl_type) => {
@@ -325,7 +339,7 @@ impl<'a, L: Language> CodeGenerator<'a, L> {
                     AbstractDataType::Value,
                     code_gen_context,
                 )?;
-                self.generate_struct_field(tera_fields, type_name, "value")?;
+                self.generate_struct_field(tera_fields, type_name, isl_type.name(), "value")?;
             }
             _ => {}
         }
@@ -337,11 +351,13 @@ impl<'a, L: Language> CodeGenerator<'a, L> {
         &mut self,
         tera_fields: &mut Vec<Field>,
         abstract_data_type_name: String,
+        isl_type_name: String,
         field_name: &str,
     ) -> CodeGenResult<()> {
         tera_fields.push(Field {
             name: field_name.to_string(),
             value: abstract_data_type_name,
+            isl_type_name,
         });
         Ok(())
     }

--- a/src/bin/ion/commands/beta/generate/generator.rs
+++ b/src/bin/ion/commands/beta/generate/generator.rs
@@ -10,7 +10,7 @@ use ion_schema::isl::IslSchema;
 use ion_schema::system::SchemaSystem;
 use std::collections::HashMap;
 use std::fs;
-use std::fs::{File, OpenOptions};
+use std::fs::OpenOptions;
 use std::io::Write;
 use std::marker::PhantomData;
 use std::path::Path;
@@ -280,7 +280,7 @@ impl<'a, L: Language> CodeGenerator<'a, L> {
                 );
         }
 
-        self.render_generated_code(&isl_type_name, &mut context, &mut code_gen_context)
+        self.render_generated_code(isl_type_name, &mut context, &mut code_gen_context)
     }
 
     fn render_generated_code(

--- a/src/bin/ion/commands/beta/generate/mod.rs
+++ b/src/bin/ion/commands/beta/generate/mod.rs
@@ -34,9 +34,8 @@ impl IonCliCommand for GenerateCommand {
             .arg(
                 Arg::new("schema")
                     .long("schema")
-                    .required(true)
                     .short('s')
-                    .help("Schema file"),
+                    .help("Schema file name or schema id"),
             )
             .arg(
                 Arg::new("language")
@@ -75,13 +74,10 @@ impl IonCliCommand for GenerateCommand {
         // Extract the user provided document authorities/ directories
         let authorities: Vec<&String> = args.get_many("directory").unwrap().collect();
 
-        // Extract schema file provided by user
-        let schema_id = args.get_one::<String>("schema").unwrap();
-
         // Set up document authorities vector
         let mut document_authorities: Vec<Box<dyn DocumentAuthority>> = vec![];
 
-        for authority in authorities {
+        for authority in &authorities {
             document_authorities.push(Box::new(FileSystemDocumentAuthority::new(Path::new(
                 authority,
             ))))
@@ -90,24 +86,43 @@ impl IonCliCommand for GenerateCommand {
         // Create a new schema system from given document authorities
         let mut schema_system = SchemaSystem::new(document_authorities);
 
-        let schema = schema_system.load_isl_schema(schema_id).unwrap();
-
-        // clean the target output directory if it already exists, before generating new code
-        if output.exists() {
-            fs::remove_dir_all(output).unwrap();
+        // Generate directories in the output path if the path doesn't exist
+        if !output.exists() {
+            fs::create_dir_all(output).unwrap();
         }
-        fs::create_dir_all(output).unwrap();
 
         println!("Started generating code...");
 
-        // generate code based on schema and programming language
-        match language {
-            "java" => CodeGenerator::<JavaLanguage>::new(output).generate(schema)?,
-            "rust" => CodeGenerator::<RustLanguage>::new(output).generate(schema)?,
-            _ => bail!(
-                "Programming language '{}' is not yet supported. Currently supported targets: 'java', 'rust'",
-                language
-            )
+        // Extract schema file provided by user
+        match args.get_one::<String>("schema") {
+            None => {
+                // generate code based on schema and programming language
+                match language {
+                    "java" =>
+                        CodeGenerator::<JavaLanguage>::new(output)
+                            .generate_code_for_authorities(&authorities, &mut schema_system)?,
+                    "rust" =>
+                        CodeGenerator::<RustLanguage>::new(output)
+                            .generate_code_for_authorities(&authorities, &mut schema_system)?,
+                    _ => bail!(
+                        "Programming language '{}' is not yet supported. Currently supported targets: 'java', 'rust'",
+                        language
+                    )
+                }
+            }
+            Some(schema_id) => {
+                let schema = schema_system.load_isl_schema(schema_id).unwrap();
+
+                // generate code based on schema and programming language
+                match language {
+                    "java" => CodeGenerator::<JavaLanguage>::new(output).generate_code_for_schema(schema)?,
+                    "rust" => CodeGenerator::<RustLanguage>::new(output).generate_code_for_schema(schema)?,
+                    _ => bail!(
+                        "Programming language '{}' is not yet supported. Currently supported targets: 'java', 'rust'",
+                        language
+                    )
+                }
+            }
         }
 
         println!("Code generation complete successfully!");

--- a/src/bin/ion/commands/beta/generate/mod.rs
+++ b/src/bin/ion/commands/beta/generate/mod.rs
@@ -76,8 +76,8 @@ impl IonCliCommand for GenerateCommand {
         // Extract output path information where the generated code will be saved
         // Create a module `ion_data_model` for storing all the generated code in the output directory
         let binding = match args.get_one::<String>("output") {
-            Some(output_path) => PathBuf::from(output_path).join("ion_data_model"),
-            None => PathBuf::from("./ion_data_model"),
+            Some(output_path) => PathBuf::from(output_path),
+            None => PathBuf::from("./"),
         };
 
         let output = binding.as_path();

--- a/src/bin/ion/commands/beta/generate/templates/java/class.templ
+++ b/src/bin/ion/commands/beta/generate/templates/java/class.templ
@@ -1,19 +1,19 @@
-{% if import %}
-import ion_data_model.{{ import.name | upper_camel }};
-{% endif %}
+package {{ namespace }};
+import java.util.ArrayList;
+
 public final class {{ target_kind_name }} {
 {% for field in fields -%}
        private final {{ field.value }} {{ field.name | camel }};
 {% endfor %}
 
-    public {{ target_kind_name }}({% for field in fields -%}{{ field.value }} {{ field.name }}{% if not loop.last %},{% endif %}{% endfor %}) {
+    public {{ target_kind_name }}({% for field in fields -%}{{ field.value }} {{ field.name | camel }}{% if not loop.last %},{% endif %}{% endfor %}) {
         {% for field in fields -%}
-            this.{{ field.name }} = {{ field.name }};
+            this.{{ field.name | camel }} = {{ field.name | camel }};
         {% endfor %}
     }
 
     {% for field in fields -%}public {{ field.value }} get{% filter upper_camel %}{{ field.name }}{% endfilter %}() {
-        return this.{{ field.name }};
+        return this.{{ field.name | camel }};
     }
     {% endfor %}
 }

--- a/src/bin/ion/commands/beta/generate/templates/rust/import.templ
+++ b/src/bin/ion/commands/beta/generate/templates/rust/import.templ
@@ -1,0 +1,1 @@
+use ion_rs::{IonResult, IonReader, Reader, IonWriter, StreamItem};

--- a/src/bin/ion/commands/beta/generate/templates/rust/mod.templ
+++ b/src/bin/ion/commands/beta/generate/templates/rust/mod.templ
@@ -1,3 +1,0 @@
-{% for module in modules -%}
-pub mod {{ module }};
-{% endfor %}

--- a/src/bin/ion/commands/beta/generate/templates/rust/struct.templ
+++ b/src/bin/ion/commands/beta/generate/templates/rust/struct.templ
@@ -29,12 +29,12 @@ impl {{ target_kind_name }} {
     pub fn read_from(reader: &mut Reader) -> IonResult<Self> {
         let mut abstract_data_type = {{ target_kind_name }}::default();
         {% if abstract_data_type == "Value"%}
-            abstract_data_type.value = {% if target_kind_name | is_built_in_type == false %}
-                                            {{ target_kind_name }}::read_from(reader)?;
+            abstract_data_type.value = {% if fields[0].value | is_built_in_type == false %}
+                                            {{ fields[0].value }}::read_from(reader)?;
                                         {% else %}
-                                            reader.read_{{ target_kind_name }}()?;
+                                            reader.read_{% if fields[0].isl_type_name == "symbol" %}symbol()?.text().unwrap(){% else %}{{ fields[0].value | replace(from="string", to ="str") }}()?{% endif %}{% if fields[0].value | lower == "string" %} .to_string() {% endif %};
                                         {% endif %}
-        {% elif abstract_data_type is object and abstract_data_type | get(key="Structure") %}
+        {% elif abstract_data_type is object and abstract_data_type is containing("Structure") %}
             reader.step_in()?;
             while reader.next()? != StreamItem::Nothing {
                 if let Some(field_name) = reader.field_name()?.text() {
@@ -43,21 +43,21 @@ impl {{ target_kind_name }} {
                             {% if field.value | is_built_in_type == false %}
                                  "{{ field.name }}" => { abstract_data_type.{{ field.name | snake }} = {{ field.value }}::read_from(reader)?; }
                             {% else %}
-                                "{{ field.name }}" => { abstract_data_type.{{ field.name | snake}} = reader.read_{{ field.value | lower }}()?; }
+                                "{{ field.name }}" => { abstract_data_type.{{ field.name | snake}} = reader.read_{% if field.isl_type_name == "symbol" %}symbol()?.text().unwrap(){% else %}{{ field.value | lower | replace(from="string", to ="str") }}()?{% endif %}{% if field.value | lower== "string" %} .to_string() {% endif %}; }
                             {% endif %}
                         {% endfor %}
                      _ => {
                         {% if abstract_data_type["Structure"] %}
                             return IonResult::decoding_error(
                                 "Can not read field name:{{ field.name }} for {{ target_kind_name }} as it doesn't exist in the given schema type definition."
-                            )
+                            );
                         {% endif %}
                      }
                     }
                 }
             }
             reader.step_out()?;
-        {% elif abstract_data_type is object and abstract_data_type | get(key="Sequence")  %}
+        {% elif abstract_data_type is object and abstract_data_type is containing("Sequence")  %}
              reader.step_in()?;
              abstract_data_type.value = {
                  let mut values = vec![];
@@ -66,12 +66,14 @@ impl {{ target_kind_name }} {
                     {% if abstract_data_type["Sequence"] | is_built_in_type == false %}
                         values.push({{ abstract_data_type["Sequence"] }}::read_from(reader)?);
                     {% else %}
-                        values.push(reader.read_{{ abstract_data_type["Sequence"] | lower }}()?);
+                        values.push(reader.read_{% if fields[0].isl_type_name == "symbol" %}symbol()?.text().unwrap(){% else %}{{ abstract_data_type["Sequence"] | lower | replace(from="string", to ="str") }}()?{% endif %}{% if abstract_data_type["Sequence"] | lower== "string" %} .to_string() {% endif %});
                     {% endif %}
                 }
                 values
              };
              reader.step_out()?;
+        {% else %}
+            return IonResult::decoding_error("Can not resolve read API template for {{ target_kind_name }}");
         {% endif %}
      Ok(abstract_data_type)
     }
@@ -79,32 +81,31 @@ impl {{ target_kind_name }} {
     pub fn write_to<W: IonWriter>(&self, writer: &mut W) -> IonResult<()> {
         {% if abstract_data_type == "Value" %}
             {% for field in fields %}
-                {% if field.value | is_built_in_type ==false  %}
+                {% if field.value | is_built_in_type == false  %}
                     self.{{ field.name | snake }}.write_to(writer)?;
                 {% else %}
-                    writer.write_{{ field.value | lower }}(self.value)?;
+                    writer.write_{% if field.isl_type_name == "symbol" %}symbol{% else %}{{ field.value | lower }}{% endif %}(self.value)?;
                 {% endif %}
             {% endfor %}
-        {% elif abstract_data_type is object and abstract_data_type | get(key="Structure") %}
+        {% elif abstract_data_type is object and abstract_data_type is containing("Structure") %}
             writer.step_in(IonType::Struct)?;
             {% for field in fields %}
             writer.set_field_name("{{ field.name }}");
                 {% if field.value | is_built_in_type == false %}
                     self.{{ field.name | snake }}.write_to(writer)?;
                 {% else %}
-                    writer.write_{{ field.value | lower }}(self.{{ field.name }})?;
                     {# TODO: Change the following `to_owned` to only be used when writing i64,f32,f64,bool which require owned value as input #}
-                    writer.write_{{ field.value | lower }}(self.{{ field.name | snake }}.to_owned())?;
+                    writer.write_{% if field.isl_type_name == "symbol" %}symbol{% else %}{{ field.value | lower }}{% endif %}(self.{{ field.name | snake }}.to_owned())?;
                 {% endif %}
             {% endfor %}
             writer.step_out()?;
-        {% elif abstract_data_type is object and abstract_data_type | get(key="Sequence")  %}
+        {% elif abstract_data_type is object and abstract_data_type is containing("Sequence")  %}
             writer.step_in(IonType::List)?;
-            for value in self.value {
+            for value in &self.value {
                 {% if abstract_data_type["Sequence"] | is_built_in_type  == false %}
                     value.write_to(writer)?;
                 {% else %}
-                   writer.write_{{ abstract_data_type["Sequence"] | lower }}(value)?;
+                   writer.write_{% if fields[0].isl_type_name == "symbol" %}symbol{% else %}{{ abstract_data_type["Sequence"] | lower }}{% endif %}(value.to_owned())?;
                 {% endif %}
             }
             writer.step_out()?;

--- a/src/bin/ion/commands/beta/generate/templates/rust/struct.templ
+++ b/src/bin/ion/commands/beta/generate/templates/rust/struct.templ
@@ -1,8 +1,3 @@
-use ion_rs::{IonResult, IonReader, Reader, IonWriter, StreamItem};
-{% for import in imports %}
-use crate::ion_data_model::{{ import.name | snake }}::{{ import.name | upper_camel }};
-{% endfor %}
-
 #[derive(Debug, Clone, Default)]
 pub struct {{ target_kind_name }} {
 {% for field in fields -%}

--- a/src/bin/ion/commands/beta/generate/utils.rs
+++ b/src/bin/ion/commands/beta/generate/utils.rs
@@ -13,13 +13,6 @@ pub struct Field {
     pub(crate) isl_type_name: String,
 }
 
-/// Represents an import in a generated code file.
-/// This will be used by template engine to fill import statements of a type definition.
-#[derive(Serialize)]
-pub struct Import {
-    pub(crate) name: String,
-}
-
 pub trait Language {
     /// Provides a file extension based on programming language
     fn file_extension() -> String;
@@ -122,8 +115,8 @@ impl Language for RustLanguage {
         "rust".to_string()
     }
 
-    fn file_name_for_type(name: &str) -> String {
-        name.to_case(Case::Snake)
+    fn file_name_for_type(_name: &str) -> String {
+        "ion_generated_code".to_string()
     }
 
     fn target_type(ion_schema_type: &IonSchemaType) -> String {

--- a/src/bin/ion/commands/beta/generate/utils.rs
+++ b/src/bin/ion/commands/beta/generate/utils.rs
@@ -10,6 +10,7 @@ use std::fmt::{Display, Formatter};
 pub struct Field {
     pub(crate) name: String,
     pub(crate) value: String,
+    pub(crate) isl_type_name: String,
 }
 
 /// Represents an import in a generated code file.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -220,8 +220,7 @@ fn test_write_all_values(#[case] number: i32, #[case] expected_output: &str) -> 
 
 #[cfg(feature = "beta-subcommands")]
 #[rstest]
-#[case(
-    "simple_struct",
+#[case::simple_struct(
     r#"
         type::{
          name: simple_struct,
@@ -234,8 +233,7 @@ fn test_write_all_values(#[case] number: i32, #[case] expected_output: &str) -> 
     &["id: i64", "name: String"],
     &["pub fn name(&self) -> &String {", "pub fn id(&self) -> &i64 {"]
 )]
-#[case(
-    "value_struct",
+#[case::value_struct(
     r#"
         type::{
          name: value_struct,
@@ -245,8 +243,7 @@ fn test_write_all_values(#[case] number: i32, #[case] expected_output: &str) -> 
     &["value: i64"],
     &["pub fn value(&self) -> &i64 {"]
 )]
-#[case(
-    "sequence_struct",
+#[case::sequence_struct(
     r#"
         type::{
          name: sequence_struct,
@@ -256,8 +253,7 @@ fn test_write_all_values(#[case] number: i32, #[case] expected_output: &str) -> 
     &["value: Vec<String>"],
     &["pub fn value(&self) -> &Vec<String> {"]
 )]
-#[case(
-    "struct_with_reference_field",
+#[case::struct_with_reference_field(
     r#"
         type::{
          name: struct_with_reference_field,
@@ -274,8 +270,7 @@ fn test_write_all_values(#[case] number: i32, #[case] expected_output: &str) -> 
     &["reference: OtherType"],
     &["pub fn reference(&self) -> &OtherType {"]
 )]
-#[case(
-    "struct_with_anonymous_type",
+#[case::struct_with_anonymous_type(
     r#"
         type::{
          name: struct_with_anonymous_type,
@@ -289,7 +284,6 @@ fn test_write_all_values(#[case] number: i32, #[case] expected_output: &str) -> 
 )]
 /// Calls ion-cli beta generate with different schema file. Pass the test if the return value contains the expected properties and accessors.
 fn test_code_generation_in_rust(
-    #[case] test_name: &str,
     #[case] test_schema: &str,
     #[case] expected_properties: &[&str],
     #[case] expected_accessors: &[&str],
@@ -313,10 +307,7 @@ fn test_code_generation_in_rust(
         temp_dir.path().to_str().unwrap(),
     ]);
     let command_assert = cmd.assert();
-    let output_file_path = temp_dir
-        .path()
-        .join("ion_data_model")
-        .join(format!("{}.rs", test_name));
+    let output_file_path = temp_dir.path().join("ion_generated_code.rs");
     command_assert.success();
     let contents =
         fs::read_to_string(output_file_path).expect("Should have been able to read the file");
@@ -424,14 +415,13 @@ fn test_code_generation_in_java(
         temp_dir.path().to_str().unwrap(),
         "--language",
         "java",
+        "--namespace",
+        "org.example",
         "--directory",
         temp_dir.path().to_str().unwrap(),
     ]);
     let command_assert = cmd.assert();
-    let output_file_path = temp_dir
-        .path()
-        .join("ion_data_model")
-        .join(format!("{}.java", test_name));
+    let output_file_path = temp_dir.path().join(format!("{}.java", test_name));
     command_assert.success();
     let contents = fs::read_to_string(output_file_path).expect("Can not read generated code file.");
     for expected_property in expected_properties {


### PR DESCRIPTION
### Issue #88:

### Description of changes:
This PR works on adding set-up changes for integration roundtrip tests on generated code

### List of changes:
- Adds some changes for struct templates, that were resulting in specific errors with roundtrip testing
  - Replaces `to_string()?` with `to_str()?.to_string()`. (`to_string()` would return a raw string e.g. "\"hello\"" whereas `to_str()` returns a string value as `"hello"`)
  - Adds `isl_type_name` property in `Field` this helps store `symbol` as Rust/Java string but when writing it as Ion it will use `write_symbol` using `write_{{ field.isl_type_name}}`.
- Add a namespace option for java code generation (This option is only required when `--language` option is set as `java`).
- Adds changes to use only a single module with all generated data models in Rust. Generated module is named as `ion_generated_code.rs`. This will help in importing entire file using [`include!`](https://doc.rust-lang.org/std/macro.include.html) macro and also simplifies attaching a single file as a module in any Rust crate. More information can be found in Rust guide on code generation: https://doc.rust-lang.org/cargo/reference/build-script-examples.html#code-generation
- Adds changes to generate code for all schema files in a directory/authority.
- Adds changes to current tests and clippy changes.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
