### PR TITLE
Upgrade to `ion_rs` dependency to v1.0.0-rc.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,12 +120,6 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -426,17 +420,6 @@ name = "delegate"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d358e0ec5c59a5e1603b933def447096886121660fc680dc1e64a0753981fe3c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "delegate"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee5df75c70b95bd3aacc8e2fd098797692fb1d54121019c4de481e42f04c8a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -857,7 +840,6 @@ dependencies = [
  "convert_case",
  "flate2",
  "infer",
- "ion-rs 1.0.0-rc.3",
  "ion-rs 1.0.0-rc.4",
  "ion-schema",
  "matches",
@@ -895,28 +877,6 @@ dependencies = [
 
 [[package]]
 name = "ion-rs"
-version = "1.0.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4048cdda3ac98a729cdbac81a4dbcae988bdf01696da36244d65c1d234ee93a"
-dependencies = [
- "arrayvec",
- "base64 0.12.3",
- "bumpalo",
- "bytes",
- "chrono",
- "delegate 0.10.0",
- "nom",
- "num-bigint 0.4.4",
- "num-integer",
- "num-traits",
- "serde",
- "serde_with 2.3.3",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "ion-rs"
 version = "1.0.0-rc.4"
 dependencies = [
  "arrayvec",
@@ -929,7 +889,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "serde_with 3.8.1",
+ "serde_with",
  "smallvec",
  "thiserror",
 ]
@@ -1480,22 +1440,6 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "serde",
- "serde_json",
- "serde_with_macros 2.3.3",
- "time",
-]
-
-[[package]]
-name = "serde_with"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
@@ -1508,20 +1452,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros 3.8.1",
+ "serde_with_macros",
  "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.50",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,6 +878,8 @@ dependencies = [
 [[package]]
 name = "ion-rs"
 version = "1.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87db81c1c2e08fd2de74c8dc62fbc4d6f192a34a883dafe21a00cad7a037e3da"
 dependencies = [
  "arrayvec",
  "base64 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bigdecimal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.1"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c764d619ca78fccbf3069b37bd7af92577f044bb15236036662d79b6559f25b7"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -435,6 +441,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "delegate"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -750,6 +767,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ice_code"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6524844f553e8da5999f3000cf11d3f1ff926bb03fc087441c7b86dee4a7d48"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +813,7 @@ checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -833,7 +857,8 @@ dependencies = [
  "convert_case",
  "flate2",
  "infer",
- "ion-rs 1.0.0-rc.3",
+ "ion-rs 1.0.0-rc.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ion-rs 1.0.0-rc.3 (git+https://github.com/amazon-ion/ion-rust.git)",
  "ion-schema",
  "matches",
  "memmap",
@@ -843,6 +868,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tera",
+ "termcolor",
  "thiserror",
  "zstd",
 ]
@@ -884,7 +910,27 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "serde_with",
+ "serde_with 2.3.3",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "ion-rs"
+version = "1.0.0-rc.3"
+source = "git+https://github.com/amazon-ion/ion-rust.git#eab334e79e420d5a5928918ce7f1ac57741f9d3a"
+dependencies = [
+ "arrayvec",
+ "base64 0.12.3",
+ "bumpalo",
+ "chrono",
+ "delegate 0.12.0",
+ "ice_code",
+ "nom",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "serde_with 3.8.1",
  "smallvec",
  "thiserror",
 ]
@@ -1445,7 +1491,25 @@ dependencies = [
  "indexmap 1.9.3",
  "serde",
  "serde_json",
- "serde_with_macros",
+ "serde_with_macros 2.3.3",
+ "time",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.3",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros 3.8.1",
  "time",
 ]
 
@@ -1454,6 +1518,18 @@ name = "serde_with_macros"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1570,6 +1646,15 @@ dependencies = [
  "serde_json",
  "slug",
  "unic-segment",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,6 @@ dependencies = [
  "ion-rs 1.0.0-rc.4",
  "ion-schema",
  "matches",
- "memmap",
  "pager",
  "rstest",
  "serde",
@@ -993,16 +992,6 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
-
-[[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "minimal-lexical"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,8 +857,8 @@ dependencies = [
  "convert_case",
  "flate2",
  "infer",
- "ion-rs 1.0.0-rc.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ion-rs 1.0.0-rc.3 (git+https://github.com/amazon-ion/ion-rust.git)",
+ "ion-rs 1.0.0-rc.3",
+ "ion-rs 1.0.0-rc.4",
  "ion-schema",
  "matches",
  "memmap",
@@ -917,8 +917,7 @@ dependencies = [
 
 [[package]]
 name = "ion-rs"
-version = "1.0.0-rc.3"
-source = "git+https://github.com/amazon-ion/ion-rust.git#eab334e79e420d5a5928918ce7f1ac57741f9d3a"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrayvec",
  "base64 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,7 +840,7 @@ dependencies = [
  "convert_case",
  "flate2",
  "infer",
- "ion-rs 1.0.0-rc.4",
+ "ion-rs 1.0.0-rc.5",
  "ion-schema",
  "matches",
  "pager",
@@ -876,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "ion-rs"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87db81c1c2e08fd2de74c8dc62fbc4d6f192a34a883dafe21a00cad7a037e3da"
+checksum = "ae6628b313b01f34e167393a688a78ce907ff7307cb9e4a93c9d3599cabb1b03"
 dependencies = [
  "arrayvec",
  "base64 0.12.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ colored = "2.0.0"
 flate2 = "1.0"
 infer = "0.15.0"
 ion-rs = { version = "1.0.0-rc.2", features = ["experimental"] }
-#new-ion-rs = { package = "ion-rs", version = "1.0.0-rc.3", path = "../ion-rust", features = ["experimental"] }
-new-ion-rs = { package = "ion-rs", git = "https://github.com/amazon-ion/ion-rust.git", features = ["experimental"] }
+new-ion-rs = { package = "ion-rs", version = "1.0.0-rc.4", path = "../ion-rust", features = ["experimental"] }
+# new-ion-rs = { package = "ion-rs", git = "https://github.com/amazon-ion/ion-rust.git", features = ["experimental"] }
 memmap = "0.7.0"
 tempfile = "3.2.0"
 ion-schema = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ clap = { version = "4.0.17", features = ["cargo"] }
 colored = "2.0.0"
 flate2 = "1.0"
 infer = "0.15.0"
-ion-rs = { version = "1.0.0-rc.2", features = ["experimental"] }
-new-ion-rs = { package = "ion-rs", version = "1.0.0-rc.4", path = "../ion-rust", features = ["experimental"] }
+#ion-rs = { version = "1.0.0-rc.2", features = ["experimental"] }
+ion-rs = { package = "ion-rs", version = "1.0.0-rc.4", path = "../ion-rust", features = ["experimental"] }
 # new-ion-rs = { package = "ion-rs", git = "https://github.com/amazon-ion/ion-rust.git", features = ["experimental"] }
 memmap = "0.7.0"
 tempfile = "3.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,18 +17,21 @@ clap = { version = "4.0.17", features = ["cargo"] }
 colored = "2.0.0"
 flate2 = "1.0"
 infer = "0.15.0"
-ion-rs = {version = "1.0.0-rc.2", features = ["experimental"]}
+ion-rs = { version = "1.0.0-rc.2", features = ["experimental"] }
+#new-ion-rs = { package = "ion-rs", version = "1.0.0-rc.3", path = "../ion-rust", features = ["experimental"] }
+new-ion-rs = { package = "ion-rs", git = "https://github.com/amazon-ion/ion-rust.git", features = ["experimental"] }
 memmap = "0.7.0"
 tempfile = "3.2.0"
 ion-schema = "0.10.0"
 serde = { version = "1.0.163", features = ["derive"] }
-serde_json = { version = "1.0.81", features = [ "arbitrary_precision", "preserve_order" ] }
+serde_json = { version = "1.0.81", features = ["arbitrary_precision", "preserve_order"] }
 base64 = "0.21.1"
-tera = {  version = "1.18.1", optional = true }
+tera = { version = "1.18.1", optional = true }
 convert_case = { version = "0.6.0", optional = true }
 matches = "0.1.10"
 thiserror = "1.0.50"
 zstd = "0.13.0"
+termcolor = "1.4.1"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 pager = "0.16.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ colored = "2.0.0"
 flate2 = "1.0"
 infer = "0.15.0"
 ion-rs = { version = "1.0.0-rc.4", features = ["experimental"] }
-memmap = "0.7.0"
 tempfile = "3.2.0"
 ion-schema = "0.10.0"
 serde = { version = "1.0.163", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4.0.17", features = ["cargo"] }
 colored = "2.0.0"
 flate2 = "1.0"
 infer = "0.15.0"
-ion-rs = { version = "1.0.0-rc.4", features = ["experimental"] }
+ion-rs = { version = "1.0.0-rc.5", features = ["experimental"] }
 tempfile = "3.2.0"
 ion-schema = "0.10.0"
 serde = { version = "1.0.163", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,7 @@ clap = { version = "4.0.17", features = ["cargo"] }
 colored = "2.0.0"
 flate2 = "1.0"
 infer = "0.15.0"
-#ion-rs = { version = "1.0.0-rc.2", features = ["experimental"] }
-ion-rs = { package = "ion-rs", version = "1.0.0-rc.4", path = "../ion-rust", features = ["experimental"] }
-# new-ion-rs = { package = "ion-rs", git = "https://github.com/amazon-ion/ion-rust.git", features = ["experimental"] }
+ion-rs = { version = "1.0.0-rc.4", features = ["experimental"] }
 memmap = "0.7.0"
 tempfile = "3.2.0"
 ion-schema = "0.10.0"

--- a/src/bin/ion/commands/beta/count.rs
+++ b/src/bin/ion/commands/beta/count.rs
@@ -1,7 +1,7 @@
 use crate::commands::{IonCliCommand, WithIonCliArgument};
 use anyhow::{Context, Result};
 use clap::{ArgMatches, Command};
-use new_ion_rs::*;
+use ion_rs::*;
 use std::fs::File;
 use std::io::{stdin, BufReader, StdinLock};
 

--- a/src/bin/ion/commands/beta/count.rs
+++ b/src/bin/ion/commands/beta/count.rs
@@ -1,7 +1,7 @@
 use crate::commands::{IonCliCommand, WithIonCliArgument};
 use anyhow::{Context, Result};
 use clap::{ArgMatches, Command};
-use ion_rs::*;
+use new_ion_rs::*;
 use std::fs::File;
 use std::io::{stdin, BufReader, StdinLock};
 
@@ -25,13 +25,13 @@ impl IonCliCommand for CountCommand {
             for input_file in input_file_iter {
                 let file = File::open(input_file)
                     .with_context(|| format!("Could not open file '{}'", input_file))?;
-                let mut reader = ReaderBuilder::new().build(file)?;
+                let mut reader = Reader::new(AnyEncoding, file)?;
                 print_top_level_value_count(&mut reader)?;
             }
         } else {
             let input: StdinLock = stdin().lock();
             let buf_reader = BufReader::new(input);
-            let mut reader = ReaderBuilder::new().build(buf_reader)?;
+            let mut reader = Reader::new(AnyEncoding, buf_reader)?;
             print_top_level_value_count(&mut reader)?;
         };
 
@@ -39,15 +39,9 @@ impl IonCliCommand for CountCommand {
     }
 }
 
-fn print_top_level_value_count(reader: &mut Reader) -> Result<()> {
+fn print_top_level_value_count<I: IonInput>(reader: &mut Reader<AnyEncoding, I>) -> Result<()> {
     let mut count: usize = 0;
-    loop {
-        let item = reader
-            .next()
-            .with_context(|| "could not count values in Ion stream")?;
-        if item == StreamItem::Nothing {
-            break;
-        }
+    while let Some(_) = reader.next()? {
         count += 1;
     }
     println!("{}", count);

--- a/src/bin/ion/commands/beta/generate/utils.rs
+++ b/src/bin/ion/commands/beta/generate/utils.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use std::fmt::{Display, Formatter};
 
 /// Represents a field that will be added to generated data model.
-/// This will be used by the template engine to fill properties of a struct/classs.
+/// This will be used by the template engine to fill properties of a struct/class.
 #[derive(Serialize)]
 pub struct Field {
     pub(crate) name: String,

--- a/src/bin/ion/commands/beta/inspect.rs
+++ b/src/bin/ion/commands/beta/inspect.rs
@@ -201,8 +201,7 @@ trait CommentFn<'x>: FnMut(&mut OutputRef, LazyValue<'x, AnyEncoding>) -> Result
 
 impl<'x, F> CommentFn<'x> for F where
     F: FnMut(&mut OutputRef, LazyValue<'x, AnyEncoding>) -> Result<bool>
-{
-}
+{}
 
 /// Returns a `CommentFn` implementation that does nothing.
 fn no_comment<'x>() -> impl CommentFn<'x> {
@@ -283,15 +282,6 @@ impl<'a, 'b> IonInspector<'a, 'b> {
                 _ => unimplemented!("a new SystemStreamItem variant was added"),
             }
 
-            // Notice that we wait until _after_ the item has been inspected above to set the
-            // `skip_complete` flag. This is because the offset specified by `--skip-bytes` may
-            // have been located somewhere inside the item and the inspector needed to look for
-            // that point within its nested values. If this happens, the inspector will set the
-            // `skip_complete` flag when it reaches that offset at a deeper level of nesting.
-            // When it reaches this point, `skip_complete` will already be true. However, if the
-            // offset fell at the beginning of a top level value, the line below will set the flag
-            // for the first time.
-            self.skip_complete = true;
             is_first_item = false;
         }
         self.output.write_all(END_OF_TABLE.as_bytes())?;
@@ -321,7 +311,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
     ///    * `None`, then there is no stream-level entity backing the item. These will always be
     ///              inspected; if the e-expression that produced the value was not beyond the limit,
     ///              none of the ephemeral values it produces are either.
-    fn is_past_limit<T: HasRange>(&mut self, maybe_item: &Option<T>) -> bool {
+    fn is_past_limit<T: HasRange>(&self, maybe_item: &Option<T>) -> bool {
         let limit = self.bytes_to_skip.saturating_add(self.limit_bytes);
         maybe_item
             .as_ref()
@@ -629,7 +619,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         value_delimiter: &str,
         closing_delimiter: &str,
         trailing_delimiter: &str,
-        nested_values: impl IntoIterator<Item = IonResult<LazyValue<'x, AnyEncoding>>>,
+        nested_values: impl IntoIterator<Item=IonResult<LazyValue<'x, AnyEncoding>>>,
         nested_raw_values: impl LazyRawSequence<'x, v1_0::Binary>,
         raw_value: LazyRawBinaryValue,
         mut value_comment_fn: impl CommentFn<'x>,

--- a/src/bin/ion/commands/beta/inspect.rs
+++ b/src/bin/ion/commands/beta/inspect.rs
@@ -263,9 +263,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
             match item {
                 SystemStreamItem::SymbolTable(lazy_struct) => {
                     let is_append = lazy_struct.get("imports")?
-                        == Some(ValueRef::Symbol(SymbolRef::with_text(
-                            "$ion_symbol_taqgble",
-                        )));
+                        == Some(ValueRef::Symbol(SymbolRef::with_text("$ion_symbol_table")));
                     if !is_append {
                         next_symbol_id = 10; // First available SID after system symbols in Ion 1.0
                     }
@@ -639,7 +637,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         self.inspect_binary_1_0_container_header(raw_value)?;
         self.write_indentation(depth)?;
         self.with_style(text_ion_style(), |out| {
-            write!(out, "{opening_delimiter}\n")?;
+            write!(out, "{opening_delimiter}")?;
             Ok(())
         })?;
 
@@ -856,7 +854,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
                 return self.inspect_value(SYMBOL_LIST_DEPTH, ",", field.value(), |out, _value| {
                     out.write_all(b" // Invalid, ignored")?;
                     Ok(true)
-                })
+                });
             }
         };
 

--- a/src/bin/ion/commands/beta/inspect.rs
+++ b/src/bin/ion/commands/beta/inspect.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use clap::{Arg, ArgMatches, Command};
-use new_ion_rs::*;
+use ion_rs::*;
 
 use crate::commands::{IonCliCommand, WithIonCliArgument};
 

--- a/src/bin/ion/commands/beta/inspect.rs
+++ b/src/bin/ion/commands/beta/inspect.rs
@@ -201,7 +201,8 @@ trait CommentFn<'x>: FnMut(&mut OutputRef, LazyValue<'x, AnyEncoding>) -> Result
 
 impl<'x, F> CommentFn<'x> for F where
     F: FnMut(&mut OutputRef, LazyValue<'x, AnyEncoding>) -> Result<bool>
-{}
+{
+}
 
 /// Returns a `CommentFn` implementation that does nothing.
 fn no_comment<'x>() -> impl CommentFn<'x> {
@@ -619,7 +620,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         value_delimiter: &str,
         closing_delimiter: &str,
         trailing_delimiter: &str,
-        nested_values: impl IntoIterator<Item=IonResult<LazyValue<'x, AnyEncoding>>>,
+        nested_values: impl IntoIterator<Item = IonResult<LazyValue<'x, AnyEncoding>>>,
         nested_raw_values: impl LazyRawSequence<'x, v1_0::Binary>,
         raw_value: LazyRawBinaryValue,
         mut value_comment_fn: impl CommentFn<'x>,

--- a/src/bin/ion/commands/beta/mod.rs
+++ b/src/bin/ion/commands/beta/mod.rs
@@ -4,18 +4,18 @@ pub mod from;
 #[cfg(feature = "experimental-code-gen")]
 pub mod generate;
 pub mod head;
+pub mod inspect;
 pub mod primitive;
 pub mod schema;
 pub mod symtab;
 pub mod to;
-pub mod inspect;
 
 use crate::commands::beta::count::CountCommand;
-use crate::commands::beta::inspect::InspectCommand;
 use crate::commands::beta::from::FromNamespace;
 #[cfg(feature = "experimental-code-gen")]
 use crate::commands::beta::generate::GenerateCommand;
 use crate::commands::beta::head::HeadCommand;
+use crate::commands::beta::inspect::InspectCommand;
 use crate::commands::beta::primitive::PrimitiveCommand;
 use crate::commands::beta::schema::SchemaNamespace;
 use crate::commands::beta::symtab::SymtabNamespace;
@@ -44,7 +44,7 @@ impl IonCliCommand for BetaNamespace {
             Box::new(ToNamespace),
             Box::new(SymtabNamespace),
             #[cfg(feature = "experimental-code-gen")]
-                Box::new(GenerateCommand),
+            Box::new(GenerateCommand),
         ]
     }
 }

--- a/src/bin/ion/commands/beta/mod.rs
+++ b/src/bin/ion/commands/beta/mod.rs
@@ -4,18 +4,18 @@ pub mod from;
 #[cfg(feature = "experimental-code-gen")]
 pub mod generate;
 pub mod head;
-pub mod inspect;
 pub mod primitive;
 pub mod schema;
 pub mod symtab;
 pub mod to;
+pub mod inspect;
 
 use crate::commands::beta::count::CountCommand;
+use crate::commands::beta::inspect::InspectCommand;
 use crate::commands::beta::from::FromNamespace;
 #[cfg(feature = "experimental-code-gen")]
 use crate::commands::beta::generate::GenerateCommand;
 use crate::commands::beta::head::HeadCommand;
-use crate::commands::beta::inspect::InspectCommand;
 use crate::commands::beta::primitive::PrimitiveCommand;
 use crate::commands::beta::schema::SchemaNamespace;
 use crate::commands::beta::symtab::SymtabNamespace;
@@ -44,7 +44,7 @@ impl IonCliCommand for BetaNamespace {
             Box::new(ToNamespace),
             Box::new(SymtabNamespace),
             #[cfg(feature = "experimental-code-gen")]
-            Box::new(GenerateCommand),
+                Box::new(GenerateCommand),
         ]
     }
 }

--- a/src/bin/ion/commands/beta/primitive.rs
+++ b/src/bin/ion/commands/beta/primitive.rs
@@ -1,7 +1,7 @@
 use crate::commands::IonCliCommand;
 use anyhow::{Context, Result};
 use clap::{Arg, ArgMatches, Command};
-use ion_rs::{VarInt, VarUInt};
+use ion_rs::v1_0::{VarInt, VarUInt};
 
 pub struct PrimitiveCommand;
 

--- a/src/bin/ion/commands/beta/symtab/filter.rs
+++ b/src/bin/ion/commands/beta/symtab/filter.rs
@@ -14,7 +14,6 @@ impl IonCliCommand for SymtabFilterCommand {
     }
 
     fn about(&self) -> &'static str {
-        // XXX Currently only supports binary input
         "Filters user data out of an Ion stream, leaving only the symbol table(s) behind."
     }
 

--- a/src/bin/ion/commands/beta/symtab/filter.rs
+++ b/src/bin/ion/commands/beta/symtab/filter.rs
@@ -4,7 +4,7 @@ use clap::{Arg, ArgAction, ArgMatches, Command};
 use std::fs::File;
 use std::io;
 use std::io::{stdout, BufWriter, Write};
-use new_ion_rs::*;
+use ion_rs::*;
 
 pub struct SymtabFilterCommand;
 

--- a/src/bin/ion/commands/beta/symtab/filter.rs
+++ b/src/bin/ion/commands/beta/symtab/filter.rs
@@ -1,10 +1,10 @@
 use crate::commands::{IonCliCommand, WithIonCliArgument};
 use anyhow::{bail, Context, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
+use ion_rs::*;
 use std::fs::File;
 use std::io;
 use std::io::{stdout, BufWriter, Write};
-use ion_rs::*;
 
 pub struct SymtabFilterCommand;
 
@@ -94,7 +94,7 @@ pub fn filter_out_user_data(
             SystemStreamItem::EndOfStream(_) => {
                 return Ok(());
             }
-            _ => unreachable!("#[non_exhaustive] enum, current variants covered")
+            _ => unreachable!("#[non_exhaustive] enum, current variants covered"),
         };
         // If this is a text encoding, then we need delimiting space to separate
         // IVMs from their neighboring system stream items. Consider:

--- a/src/bin/ion/commands/beta/to/json.rs
+++ b/src/bin/ion/commands/beta/to/json.rs
@@ -5,7 +5,7 @@ use serde_json::{Map, Number, Value as JsonValue};
 use std::fs::File;
 use std::io::{stdin, stdout, BufWriter, Write};
 use std::str::FromStr;
-use new_ion_rs::*;
+use ion_rs::*;
 
 pub struct ToJsonCommand;
 

--- a/src/bin/ion/commands/beta/to/json.rs
+++ b/src/bin/ion/commands/beta/to/json.rs
@@ -1,12 +1,11 @@
 use crate::commands::{IonCliCommand, WithIonCliArgument};
 use anyhow::{Context, Result};
 use clap::{ArgMatches, Command};
-use ion_rs::{Element, ElementReader};
-use ion_rs::{Reader, ReaderBuilder};
 use serde_json::{Map, Number, Value as JsonValue};
 use std::fs::File;
 use std::io::{stdin, stdout, BufWriter, Write};
 use std::str::FromStr;
+use new_ion_rs::*;
 
 pub struct ToJsonCommand;
 
@@ -45,15 +44,13 @@ impl IonCliCommand for ToJsonCommand {
             for input_file in input_file_names {
                 let file = File::open(input_file.as_str())
                     .with_context(|| format!("Could not open file '{}'", &input_file))?;
-                let mut reader = ReaderBuilder::new()
-                    .build(file)
+                let mut reader = Reader::new(AnyEncoding, file)
                     .with_context(|| format!("Input file {} was not valid Ion.", &input_file))?;
                 convert(&mut reader, &mut output)?;
             }
         } else {
             // No input files were specified, run the converter on STDIN.
-            let mut reader = ReaderBuilder::new()
-                .build(stdin().lock())
+            let mut reader = Reader::new(AnyEncoding, stdin().lock())
                 .with_context(|| "Input was not valid Ion.")?;
             convert(&mut reader, &mut output)?;
         }
@@ -63,73 +60,68 @@ impl IonCliCommand for ToJsonCommand {
     }
 }
 
-pub fn convert(reader: &mut Reader, output: &mut Box<dyn Write>) -> Result<()> {
+pub fn convert(reader: &mut Reader<AnyEncoding, impl IonInput>, output: &mut Box<dyn Write>) -> Result<()> {
     const FLUSH_EVERY_N: usize = 100;
-    let mut element_count = 0usize;
-    for result in reader.elements() {
-        let element = result.with_context(|| "invalid input")?;
-        writeln!(output, "{}", to_json_value(&element)?)?;
-        element_count += 1;
-        if element_count % FLUSH_EVERY_N == 0 {
+    let mut value_count = 0usize;
+    while let Some(value) = reader.next()? {
+        writeln!(output, "{}", to_json_value(value)?)?;
+        value_count += 1;
+        if value_count % FLUSH_EVERY_N == 0 {
             output.flush()?;
         }
     }
     Ok(())
 }
 
-fn to_json_value(element: &Element) -> Result<JsonValue> {
-    if element.is_null() {
-        Ok(JsonValue::Null)
-    } else {
-        use ion_rs::Value::*;
-        let value = match element.value() {
-            Null(_ion_type) => JsonValue::Null,
-            Bool(b) => JsonValue::Bool(*b),
-            Int(i) => JsonValue::Number(
-                Number::from_str(&(*i).to_string())
-                    .with_context(|| format!("{element} could not be turned into a Number"))?,
-            ),
-            Float(f) => {
-                let value = *f;
-                if value.is_finite() {
-                    JsonValue::Number(
-                        Number::from_f64(value).with_context(|| {
-                            format!("{element} could not be turned into a Number")
-                        })?,
-                    )
-                } else {
-                    // +inf, -inf, and nan are not JSON numbers, and are written as null in
-                    // accordance with Ion's JSON down-conversion guidelines.
-                    JsonValue::Null
-                }
+fn to_json_value(value: LazyValue<AnyEncoding>) -> Result<JsonValue> {
+    use ValueRef::*;
+    let value = match value.read()? {
+        Null(_) => JsonValue::Null,
+        Bool(b) => JsonValue::Bool(b),
+        Int(i) => JsonValue::Number(Number::from(i.expect_i128()?)),
+        Float(f) if f.is_finite() => JsonValue::Number(Number::from_f64(f).expect("f64 is finite")),
+        // Special floats like +inf, -inf, and NaN are written as `null` in
+        // accordance with Ion's JSON down-conversion guidelines.
+        Float(_f) => JsonValue::Null,
+        Decimal(d) => {
+            let mut text = d.to_string().replace('d', "e");
+            if text.ends_with(".") {
+                // If there's a trailing "." with no digits of precision, discard it. JSON's `Number`
+                // type does not do anything with this information.
+                let _ = text.pop();
             }
-            Decimal(d) => JsonValue::Number(
-                Number::from_str(d.to_string().replace('d', "e").as_str())
-                    .with_context(|| format!("{element} could not be turned into a Number"))?,
-            ),
-            Timestamp(t) => JsonValue::String(t.to_string()),
-            Symbol(s) => s
-                .text()
-                .map(|text| JsonValue::String(text.to_owned()))
-                .unwrap_or_else(|| JsonValue::Null),
-            String(s) => JsonValue::String(s.text().to_owned()),
-            Blob(b) | Clob(b) => {
-                use base64::{engine::general_purpose as base64_encoder, Engine as _};
-                let base64_text = base64_encoder::STANDARD.encode(b.as_ref());
-                JsonValue::String(base64_text)
+            JsonValue::Number(
+                Number::from_str(text.as_str())
+                    .with_context(|| format!("{d} could not be turned into a Number"))?,
+            )
+        }
+        Timestamp(t) => JsonValue::String(t.to_string()),
+        Symbol(s) => s.text()
+            .map(|text| JsonValue::String(text.to_owned()))
+            .unwrap_or_else(|| JsonValue::Null),
+        String(s) => JsonValue::String(s.text().to_owned()),
+        Blob(b) | Clob(b) => {
+            use base64::{engine::general_purpose as base64_encoder, Engine as _};
+            let base64_text = base64_encoder::STANDARD.encode(b.as_ref());
+            JsonValue::String(base64_text)
+        }
+        SExp(s) => to_json_array(s.iter())?,
+        List(l) => to_json_array(l.iter())?,
+        Struct(s) => {
+            let mut map = Map::new();
+            for field in s {
+                let field = field?;
+                let name = field.name()?.text().unwrap_or("$0").to_owned();
+                let value = to_json_value(field.value())?;
+                map.insert(name, value);
             }
-            List(s) | SExp(s) => {
-                let result: Result<Vec<JsonValue>> = s.elements().map(to_json_value).collect();
-                JsonValue::Array(result?)
-            }
-            Struct(s) => {
-                let result: Result<Map<std::string::String, JsonValue>> = s
-                    .fields()
-                    .map(|(k, v)| to_json_value(v).map(|value| (k.text().unwrap().into(), value)))
-                    .collect();
-                JsonValue::Object(result?)
-            }
-        };
-        Ok(value)
-    }
+            JsonValue::Object(map)
+        }
+    };
+    Ok(value)
+}
+
+fn to_json_array<'a>(ion_values: impl IntoIterator<Item=IonResult<LazyValue<'a, AnyEncoding>>>) -> Result<JsonValue> {
+    let result: Result<Vec<JsonValue>> = ion_values.into_iter().flat_map(|v| v.map(to_json_value)).collect();
+    Ok(JsonValue::Array(result?))
 }

--- a/src/bin/ion/commands/dump.rs
+++ b/src/bin/ion/commands/dump.rs
@@ -185,8 +185,8 @@ fn auto_decompressing_reader<R>(
     mut reader: R,
     header_len: usize,
 ) -> IonResult<AutoDecompressingReader>
-    where
-        R: BufRead + 'static,
+where
+    R: BufRead + 'static,
 {
     // read header
     let mut header_bytes = vec![0; header_len];

--- a/src/bin/ion/commands/dump.rs
+++ b/src/bin/ion/commands/dump.rs
@@ -1,7 +1,7 @@
 use crate::commands::{IonCliCommand, WithIonCliArgument};
 use anyhow::{Context, Result};
 use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
-use ion_rs::*;
+use new_ion_rs::*;
 use std::fs::File;
 use std::io::{self, stdin, stdout, BufRead, BufReader, Chain, Cursor, Read, StdinLock, Write};
 
@@ -69,24 +69,26 @@ impl IonCliCommand for DumpCommand {
             for input_file in input_file_iter {
                 let file = File::open(input_file)
                     .with_context(|| format!("Could not open file '{}'", input_file))?;
-                let mut reader = if let Some(true) = args.get_one::<bool>("no-auto-decompress") {
-                    ReaderBuilder::new().build(file)?
+                if let Some(true) = args.get_one::<bool>("no-auto-decompress") {
+                    let mut reader = Reader::new(AnyEncoding, file)?;
+                    write_in_format(&mut reader, &mut output, format, values)?;
                 } else {
                     let bfile = BufReader::with_capacity(BUF_READER_CAPACITY, file);
                     let zfile = auto_decompressing_reader(bfile, INFER_HEADER_LENGTH)?;
-                    ReaderBuilder::new().build(zfile)?
+                    let mut reader = Reader::new(AnyEncoding, zfile)?;
+                    write_in_format(&mut reader, &mut output, format, values)?;
                 };
-                write_in_format(&mut reader, &mut output, format, values)?;
             }
         } else {
             let input: StdinLock = stdin().lock();
-            let mut reader = if let Some(true) = args.get_one::<bool>("no-auto-decompress") {
-                ReaderBuilder::new().build(input)?
+            if let Some(true) = args.get_one::<bool>("no-auto-decompress") {
+                let mut reader = Reader::new(AnyEncoding, input)?;
+                write_in_format(&mut reader, &mut output, format, values)?;
             } else {
                 let zinput = auto_decompressing_reader(input, INFER_HEADER_LENGTH)?;
-                ReaderBuilder::new().build(zinput)?
+                let mut reader = Reader::new(AnyEncoding, zinput)?;
+                write_in_format(&mut reader, &mut output, format, values)?;
             };
-            write_in_format(&mut reader, &mut output, format, values)?;
         }
 
         output.flush()?;
@@ -104,39 +106,27 @@ pub(crate) fn run(_command: &str, args: &ArgMatches) -> Result<()> {
 
 /// Constructs the appropriate writer for the given format, then writes all values found in the
 /// Reader to the new Writer. If `count` is specified will write at most `count` values.
-pub(crate) fn write_in_format(
-    reader: &mut Reader,
+pub(crate) fn write_in_format<I: IonInput>(
+    reader: &mut Reader<AnyEncoding, I>,
     output: &mut Box<dyn Write>,
     format: &str,
     count: Option<usize>,
 ) -> IonResult<usize> {
-    // XXX: The text formats below each have additional logic to append a newline because the
-    //      ion-rs writer doesn't handle this automatically like it should.
-    //TODO: Solve these newline issues, get rid of hack
-    // https://github.com/amazon-ion/ion-cli/issues/36
-    // https://github.com/amazon-ion/ion-rust/issues/437
-    const NEWLINE: u8 = 0x0A;
     let written = match format {
         "pretty" => {
-            let mut writer = TextWriterBuilder::pretty().build(output)?;
-            let values_written = transcribe_n_values(reader, &mut writer, count)?;
-            writer.output_mut().write_all(&[NEWLINE])?;
-            Ok(values_written)
+            let mut writer = Writer::new(v1_0::Text.with_format(TextFormat::Pretty), output)?;
+            transcribe_n_values(reader, &mut writer, count)
         }
         "text" => {
-            let mut writer = TextWriterBuilder::default().build(output)?;
-            let values_written = transcribe_n_values(reader, &mut writer, count)?;
-            writer.output_mut().write_all(&[NEWLINE])?;
-            Ok(values_written)
+            let mut writer = Writer::new(v1_0::Text.with_format(TextFormat::Compact), output)?;
+            transcribe_n_values(reader, &mut writer, count)
         }
         "lines" => {
-            let mut writer = TextWriterBuilder::lines().build(output)?;
-            let values_written = transcribe_n_values(reader, &mut writer, count)?;
-            writer.output_mut().write_all(&[NEWLINE])?;
-            Ok(values_written)
+            let mut writer = Writer::new(v1_0::Text.with_format(TextFormat::Lines), output)?;
+            transcribe_n_values(reader, &mut writer, count)
         }
         "binary" => {
-            let mut writer = BinaryWriterBuilder::new().build(output)?;
+            let mut writer = Writer::new(v1_0::Binary, output)?;
             transcribe_n_values(reader, &mut writer, count)
         }
         unrecognized => unreachable!(
@@ -149,95 +139,36 @@ pub(crate) fn write_in_format(
 
 /// Writes each value encountered in the Reader to the provided IonWriter. If `count` is specified
 /// will write at most `count` values.
-fn transcribe_n_values<W: IonWriter>(
-    reader: &mut Reader,
-    writer: &mut W,
+fn transcribe_n_values<I: IonInput, E: Encoding>(
+    reader: &mut Reader<AnyEncoding, I>,
+    writer: &mut Writer<E, &mut Box<dyn Write>>,
     count: Option<usize>,
 ) -> IonResult<usize> {
     const FLUSH_EVERY_N: usize = 100;
     let mut values_since_flush: usize = 0;
-    let mut annotations = vec![];
-    let mut index = 0;
-    loop {
-        // Could use Option::is_some_and if that reaches stable
-        if reader.depth() == 0 && matches!(count, Some(n) if n <= index) {
+    let max_items = count.unwrap_or(usize::MAX);
+    let mut index: usize = 0;
+
+    while let Some(value) = reader.next()? {
+        if index >= max_items {
             break;
         }
 
-        match reader.next()? {
-            StreamItem::Value(ion_type) | StreamItem::Null(ion_type) => {
-                if reader.has_annotations() {
-                    annotations.clear();
-                    for annotation in reader.annotations() {
-                        annotations.push(annotation?);
-                    }
-                    writer.set_annotations(&annotations);
-                }
+        writer.write(value)?;
 
-                if reader.parent_type() == Some(IonType::Struct) {
-                    writer.set_field_name(reader.field_name()?);
-                }
-
-                if reader.is_null() {
-                    writer.write_null(ion_type)?;
-                    continue;
-                }
-
-                use IonType::*;
-                match ion_type {
-                    Null => unreachable!("null values are handled prior to this match"),
-                    Bool => writer.write_bool(reader.read_bool()?)?,
-                    Int => writer.write_int(&reader.read_int()?)?,
-                    Float => {
-                        let float64 = reader.read_f64()?;
-                        let float32 = float64 as f32;
-                        if float32 as f64 == float64 {
-                            // No data lost during cast; write it as an f32
-                            writer.write_f32(float32)?;
-                        } else {
-                            writer.write_f64(float64)?;
-                        }
-                    }
-                    Decimal => writer.write_decimal(&reader.read_decimal()?)?,
-                    Timestamp => writer.write_timestamp(&reader.read_timestamp()?)?,
-                    Symbol => writer.write_symbol(reader.read_symbol()?)?,
-                    String => writer.write_string(reader.read_string()?)?,
-                    Clob => writer.write_clob(reader.read_clob()?)?,
-                    Blob => writer.write_blob(reader.read_blob()?)?,
-                    List => {
-                        reader.step_in()?;
-                        writer.step_in(List)?;
-                    }
-                    SExp => {
-                        reader.step_in()?;
-                        writer.step_in(SExp)?;
-                    }
-                    Struct => {
-                        reader.step_in()?;
-                        writer.step_in(Struct)?;
-                    }
-                }
-            }
-            StreamItem::Nothing if reader.depth() > 0 => {
-                reader.step_out()?;
-                writer.step_out()?;
-            }
-            StreamItem::Nothing => break,
-        }
-        if reader.depth() == 0 {
-            index += 1;
-            values_since_flush += 1;
-            if values_since_flush == FLUSH_EVERY_N {
-                writer.flush()?;
-                values_since_flush = 0;
-            }
+        index += 1;
+        values_since_flush += 1;
+        if values_since_flush == FLUSH_EVERY_N {
+            writer.flush()?;
+            values_since_flush = 0;
         }
     }
+
     writer.flush()?;
     Ok(index)
 }
 
-/// Autodetects a compressed byte stream and wraps the original reader
+/// Auto-detects a compressed byte stream and wraps the original reader
 /// into a reader that transparently decompresses.
 ///
 /// To support non-seekable readers like `Stdin`, we could have used a
@@ -254,8 +185,8 @@ fn auto_decompressing_reader<R>(
     mut reader: R,
     header_len: usize,
 ) -> IonResult<AutoDecompressingReader>
-where
-    R: BufRead + 'static,
+    where
+        R: BufRead + 'static,
 {
     // read header
     let mut header_bytes = vec![0; header_len];

--- a/src/bin/ion/commands/dump.rs
+++ b/src/bin/ion/commands/dump.rs
@@ -1,7 +1,7 @@
 use crate::commands::{IonCliCommand, WithIonCliArgument};
 use anyhow::{Context, Result};
 use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
-use new_ion_rs::*;
+use ion_rs::*;
 use std::fs::File;
 use std::io::{self, stdin, stdout, BufRead, BufReader, Chain, Cursor, Read, StdinLock, Write};
 

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::anyhow;
 use clap::{crate_authors, crate_version, Arg, ArgAction, ArgMatches, Command as ClapCommand};
+
 pub mod beta;
 pub mod dump;
 
@@ -69,10 +70,6 @@ pub trait IonCliCommand {
             None
         }
     }
-
-    /// Sets up the pager (e.g. `less`)  to which long text output will be directed. The default
-    /// implementation does not configure a pager.
-    fn set_up_pager(&self) {}
 
     /// The core logic of the command.
     ///

--- a/src/bin/ion/file_writer.rs
+++ b/src/bin/ion/file_writer.rs
@@ -1,7 +1,7 @@
-use termcolor::{ColorSpec, WriteColor};
+use std::fs::File;
 use std::io;
 use std::io::{BufWriter, Write};
-use std::fs::File;
+use termcolor::{ColorSpec, WriteColor};
 
 /// A buffered `io::Write` implementation that implements [`WriteColor`] by reporting that it does
 /// not support TTY escape sequences and treating all requests to change or reset the current color
@@ -22,7 +22,9 @@ pub struct FileWriter {
 
 impl FileWriter {
     pub fn new(file: File) -> Self {
-        Self { inner: BufWriter::new(file) }
+        Self {
+            inner: BufWriter::new(file),
+        }
     }
 }
 

--- a/src/bin/ion/file_writer.rs
+++ b/src/bin/ion/file_writer.rs
@@ -1,0 +1,55 @@
+use termcolor::{ColorSpec, WriteColor};
+use std::io;
+use std::io::{BufWriter, Write};
+use std::fs::File;
+
+/// A buffered `io::Write` implementation that implements [`WriteColor`] by reporting that it does
+/// not support TTY escape sequences and treating all requests to change or reset the current color
+/// as no-ops.
+//
+// When writing to a file instead of a TTY, we don't want to use `termcolor` escape sequences as
+// they would be stored as literal bytes rather than being interpreted. To achieve this, we need an
+// `io::Write` implementation that also implements `termcolor`'s `WriteColor` trait. `WriteColor`
+// allows the type to specify to whether it supports interpreting escape codes.
+//
+// We cannot implement `WriteColor` for `BufWriter<File>` directly due to Rust's coherence rules. Our
+// crate must own the trait, the implementing type, or both. The `FileWriter` type defined below
+// is a simple wrapper around a `BufWriter<File>` that implements both `io::Write` and `termcolor`'s
+// `WriteColor` trait.
+pub struct FileWriter {
+    inner: BufWriter<File>,
+}
+
+impl FileWriter {
+    pub fn new(file: File) -> Self {
+        Self { inner: BufWriter::new(file) }
+    }
+}
+
+// Delegates all `io::Write` methods to the nested `BufWriter`.
+impl Write for FileWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+impl WriteColor for FileWriter {
+    fn supports_color(&self) -> bool {
+        // FileWriter is never used to write to a TTY, so it does not support escape codes.
+        false
+    }
+
+    fn set_color(&mut self, _spec: &ColorSpec) -> io::Result<()> {
+        // When asked to change the color spec, do nothing.
+        Ok(())
+    }
+
+    fn reset(&mut self) -> io::Result<()> {
+        // When asked to reset the color spec to the default settings, do nothing.
+        Ok(())
+    }
+}

--- a/src/bin/ion/main.rs
+++ b/src/bin/ion/main.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod file_writer;
 
 use crate::commands::beta::BetaNamespace;
 use anyhow::Result;
@@ -18,7 +19,7 @@ fn main() -> Result<()> {
             // If `ion-cli` is being invoked as part of a pipeline we want to allow the pipeline to
             // to shut off without printing an error to stderr
             Some(IonError::Io(error)) if error.source().kind() == ErrorKind::BrokenPipe => {
-                return Ok(())
+                return Ok(());
             }
             _ => return Err(e),
         }

--- a/tests/code-gen-tests.rs
+++ b/tests/code-gen-tests.rs
@@ -1,12 +1,12 @@
+#![cfg(feature = "experimental-code-gen")]
+
 use anyhow::Result;
 use assert_cmd::Command;
 use rstest::rstest;
-use std::fs;
 use std::fs::File;
 use std::io::Write;
 use tempfile::TempDir;
 
-#[cfg(feature = "experimental-code-gen")]
 #[test]
 fn roundtrip_tests_for_generated_code_gradle() -> Result<()> {
     // run the gradle project defined under `code-gen-projects`,
@@ -39,7 +39,6 @@ fn roundtrip_tests_for_generated_code_gradle() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "experimental-code-gen")]
 #[test]
 fn roundtrip_tests_for_generated_code_cargo() -> Result<()> {
     // run the cargo project defined under `code-gen-projects`,
@@ -93,7 +92,7 @@ fn roundtrip_tests_for_generated_code_cargo() -> Result<()> {
 #[cfg(feature = "experimental-code-gen")]
 #[rstest]
 #[case::any_element_list(
-    r#"
+r#"
         type::{
          name: any_element_list,
          type: list, // this doesn't specify the type for elements in the list with `element` constraint


### PR DESCRIPTION
* Upgrades the `ion-cli`'s dependency on `ion_rs` from `v1.0.0-rc.2` to `v1.0.0-rc.5`.
* Removes our dependency on `memmap`; all commands are now streaming.
* Removes hack to add newlines between per-file outputs from `dump`.
* Overhauls the `inspect` command to take advantage of new tooling access APIs in the streaming reader. The new version:
   * shows opcodes and `VarUInt` lengths in a style that is distinct from that of the body of the value
   * uses Unicode box drawing to render its table
   * colors annotations and field names in the text Ion column
   * shows the symbol ID assigned to each string in a local symbol 

Fixes issues #34 and #36.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
