### PR TITLE
Promotes `inspect` out of beta

### DIFF
--- a/src/bin/ion/commands/beta/mod.rs
+++ b/src/bin/ion/commands/beta/mod.rs
@@ -4,7 +4,6 @@ pub mod from;
 #[cfg(feature = "experimental-code-gen")]
 pub mod generate;
 pub mod head;
-pub mod inspect;
 pub mod primitive;
 pub mod schema;
 pub mod symtab;
@@ -15,7 +14,6 @@ use crate::commands::beta::from::FromNamespace;
 #[cfg(feature = "experimental-code-gen")]
 use crate::commands::beta::generate::GenerateCommand;
 use crate::commands::beta::head::HeadCommand;
-use crate::commands::beta::inspect::InspectCommand;
 use crate::commands::beta::primitive::PrimitiveCommand;
 use crate::commands::beta::schema::SchemaNamespace;
 use crate::commands::beta::symtab::SymtabNamespace;
@@ -36,7 +34,6 @@ impl IonCliCommand for BetaNamespace {
     fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {
         vec![
             Box::new(CountCommand),
-            Box::new(InspectCommand),
             Box::new(PrimitiveCommand),
             Box::new(SchemaNamespace),
             Box::new(HeadCommand),

--- a/src/bin/ion/commands/inspect.rs
+++ b/src/bin/ion/commands/inspect.rs
@@ -31,7 +31,10 @@ impl IonCliCommand for InspectCommand {
     }
 
     fn about(&self) -> &'static str {
-        "Displays hex-encoded binary Ion alongside its equivalent text for human-friendly debugging."
+        "Displays hex-encoded binary Ion alongside its equivalent text Ion.
+Its output prioritizes human readability and is likely to change
+between versions. Stable output for programmatic use cases is a
+non-goal."
     }
 
     fn configure_args(&self, command: Command) -> Command {

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -3,6 +3,7 @@ use clap::{crate_authors, crate_version, Arg, ArgAction, ArgMatches, Command as 
 
 pub mod beta;
 pub mod dump;
+pub mod inspect;
 
 /// Behaviors common to all Ion CLI commands, including both namespaces (groups of commands)
 /// and the commands themselves.

--- a/src/bin/ion/main.rs
+++ b/src/bin/ion/main.rs
@@ -8,6 +8,7 @@ use ion_rs::IonError;
 use std::io::ErrorKind;
 
 use crate::commands::dump::DumpCommand;
+use crate::commands::inspect::InspectCommand;
 
 fn main() -> Result<()> {
     let root_command = RootCommand;
@@ -40,6 +41,10 @@ impl IonCliCommand for RootCommand {
     }
 
     fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>> {
-        vec![Box::new(BetaNamespace), Box::new(DumpCommand)]
+        vec![
+            Box::new(BetaNamespace),
+            Box::new(DumpCommand),
+            Box::new(InspectCommand),
+        ]
     }
 }


### PR DESCRIPTION
Also expands the `--help` text to indicate that its output is not guaranteed to be stable for the purposes of machine readability.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
