### PR TITLE
Centralizes I/O setup, adds `cat` alias for `dump` command

### DIFF
--- a/src/bin/ion/auto_decompress.rs
+++ b/src/bin/ion/auto_decompress.rs
@@ -1,0 +1,72 @@
+use ion_rs::IonResult;
+use std::io;
+use std::io::{BufRead, BufReader, Chain, Cursor, Read};
+
+/// Auto-detects a compressed byte stream and wraps the original reader
+/// into a reader that transparently decompresses.
+///
+// To support non-seekable readers like `Stdin`, we could have used a
+// full-blown buffering wrapper with unlimited rewinds, but since we only
+// need the first few magic bytes at offset 0, we cheat and instead make a
+// `Chain` reader from the buffered header followed by the original reader.
+//
+// The choice of `Chain` type here is not quite necessary: it could have
+// been simply `dyn BufRead`, but there is no `ToIonDataSource` trait
+// implementation for `dyn BufRead` at the moment.
+type AutoDecompressingReader = Chain<Box<dyn BufRead>, Box<dyn BufRead>>;
+
+pub fn auto_decompressing_reader<R>(
+    mut reader: R,
+    header_len: usize,
+) -> IonResult<AutoDecompressingReader>
+where
+    R: BufRead + 'static,
+{
+    // read header
+    let mut header_bytes = vec![0; header_len];
+    let nread = read_reliably(&mut reader, &mut header_bytes)?;
+    header_bytes.truncate(nread);
+
+    // detect compression type and wrap reader in a decompressor
+    match infer::get(&header_bytes) {
+        Some(t) => match t.extension() {
+            "gz" => {
+                // "rewind" to let the decompressor read magic bytes again
+                let header: Box<dyn BufRead> = Box::new(Cursor::new(header_bytes));
+                let chain = header.chain(reader);
+                let zreader = Box::new(BufReader::new(flate2::read::GzDecoder::new(chain)));
+                // must return a `Chain`, so prepend an empty buffer
+                let nothing: Box<dyn BufRead> = Box::new(Cursor::new(&[] as &[u8]));
+                Ok(nothing.chain(zreader))
+            }
+            "zst" => {
+                let header: Box<dyn BufRead> = Box::new(Cursor::new(header_bytes));
+                let chain = header.chain(reader);
+                let zreader = Box::new(BufReader::new(zstd::stream::read::Decoder::new(chain)?));
+                let nothing: Box<dyn BufRead> = Box::new(Cursor::new(&[] as &[u8]));
+                Ok(nothing.chain(zreader))
+            }
+            _ => {
+                let header: Box<dyn BufRead> = Box::new(Cursor::new(header_bytes));
+                Ok(header.chain(Box::new(reader)))
+            }
+        },
+        None => {
+            let header: Box<dyn BufRead> = Box::new(Cursor::new(header_bytes));
+            Ok(header.chain(Box::new(reader)))
+        }
+    }
+}
+
+/// Similar to [`Read::read()`], but loops in case of fragmented reads.
+pub fn read_reliably<R: Read>(reader: &mut R, buf: &mut [u8]) -> io::Result<usize> {
+    let mut nread = 0;
+    while nread < buf.len() {
+        match reader.read(&mut buf[nread..]) {
+            Ok(0) => break,
+            Ok(n) => nread += n,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(nread)
+}

--- a/src/bin/ion/commands/beta/from/json.rs
+++ b/src/bin/ion/commands/beta/from/json.rs
@@ -1,6 +1,8 @@
-use crate::commands::{dump, IonCliCommand, WithIonCliArgument};
 use anyhow::Result;
 use clap::{ArgMatches, Command};
+
+use crate::commands::cat::CatCommand;
+use crate::commands::{IonCliCommand, WithIonCliArgument};
 
 pub struct FromJsonCommand;
 
@@ -17,9 +19,9 @@ impl IonCliCommand for FromJsonCommand {
         command.with_input().with_output().with_format()
     }
 
-    fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
-        // Because JSON data is valid Ion, the `dump` command may be reused for converting JSON.
+    fn run(&self, command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
+        // Because JSON data is valid Ion, the `cat` command may be reused for converting JSON.
         // TODO ideally, this would perform some smarter "up-conversion".
-        dump::run("json", args)
+        CatCommand.run(command_path, args)
     }
 }

--- a/src/bin/ion/commands/beta/head.rs
+++ b/src/bin/ion/commands/beta/head.rs
@@ -1,19 +1,12 @@
-use std::fs::File;
-use std::io::{stdin, stdout, BufReader, StdinLock, Write};
-
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::{value_parser, Arg, ArgMatches, Command};
 use ion_rs::{AnyEncoding, Reader};
 
-use crate::auto_decompress::auto_decompressing_reader;
 use crate::commands::cat::CatCommand;
-use crate::commands::IonCliCommand;
+use crate::commands::{CommandIo, IonCliCommand};
 use crate::transcribe::write_n_as;
 
 pub struct HeadCommand;
-
-const BUF_READER_CAPACITY: usize = 2 << 20; // 1 MiB
-const INFER_HEADER_LENGTH: usize = 8;
 
 impl IonCliCommand for HeadCommand {
     fn name(&self) -> &'static str {
@@ -45,50 +38,12 @@ impl IonCliCommand for HeadCommand {
         // --format pretty|text|lines|binary
         // `clap` validates the specified format and provides a default otherwise.
         let format = args.get_one::<String>("format").unwrap();
-
-        // -o filename
-        let mut output: Box<dyn Write> = if let Some(output_file) = args.get_one::<String>("output")
-        {
-            let file = File::create(output_file).with_context(|| {
-                format!(
-                    "could not open file output file '{}' for writing",
-                    output_file
-                )
-            })?;
-            Box::new(file)
-        } else {
-            Box::new(stdout().lock())
-        };
-
         let num_values = *args.get_one::<usize>("values").unwrap();
 
-        if let Some(input_file_iter) = args.get_many::<String>("input") {
-            for input_file in input_file_iter {
-                let file = File::open(input_file)
-                    .with_context(|| format!("Could not open file '{}'", input_file))?;
-                if let Some(true) = args.get_one::<bool>("no-auto-decompress") {
-                    let mut reader = Reader::new(AnyEncoding, file)?;
-                    write_n_as(&mut reader, &mut output, format, num_values)?;
-                } else {
-                    let bfile = BufReader::with_capacity(BUF_READER_CAPACITY, file);
-                    let zfile = auto_decompressing_reader(bfile, INFER_HEADER_LENGTH)?;
-                    let mut reader = Reader::new(AnyEncoding, zfile)?;
-                    write_n_as(&mut reader, &mut output, format, num_values)?;
-                };
-            }
-        } else {
-            let input: StdinLock = stdin().lock();
-            if let Some(true) = args.get_one::<bool>("no-auto-decompress") {
-                let mut reader = Reader::new(AnyEncoding, input)?;
-                write_n_as(&mut reader, &mut output, format, num_values)?;
-            } else {
-                let zinput = auto_decompressing_reader(input, INFER_HEADER_LENGTH)?;
-                let mut reader = Reader::new(AnyEncoding, zinput)?;
-                write_n_as(&mut reader, &mut output, format, num_values)?;
-            };
-        }
-
-        output.flush()?;
-        Ok(())
+        CommandIo::new(args).for_each_input(|output, input| {
+            let mut reader = Reader::new(AnyEncoding, input.into_source())?;
+            write_n_as(&mut reader, output, format, num_values)?;
+            Ok(())
+        })
     }
 }

--- a/src/bin/ion/commands/cat.rs
+++ b/src/bin/ion/commands/cat.rs
@@ -2,46 +2,37 @@ use std::fs::File;
 use std::io::{stdin, stdout, BufReader, StdinLock, Write};
 
 use anyhow::{Context, Result};
-use clap::{value_parser, Arg, ArgMatches, Command};
-use ion_rs::{AnyEncoding, Reader};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use ion_rs::*;
 
 use crate::auto_decompress::auto_decompressing_reader;
-use crate::commands::cat::CatCommand;
-use crate::commands::IonCliCommand;
-use crate::transcribe::write_n_as;
+use crate::commands::{IonCliCommand, WithIonCliArgument};
+use crate::transcribe::write_all_as;
 
-pub struct HeadCommand;
+pub struct CatCommand;
 
 const BUF_READER_CAPACITY: usize = 2 << 20; // 1 MiB
 const INFER_HEADER_LENGTH: usize = 8;
 
-impl IonCliCommand for HeadCommand {
+impl IonCliCommand for CatCommand {
     fn name(&self) -> &'static str {
-        "head"
+        "cat"
     }
 
     fn about(&self) -> &'static str {
-        "Prints the specified number of top-level values in the input stream."
+        "Prints Ion in the requested format."
     }
 
     fn configure_args(&self, command: Command) -> Command {
-        // Same flags as `cat`, but with an added `--values` flag to specify the number of values to
-        // write.
-        CatCommand.configure_args(command).arg(
-            Arg::new("values")
-                .long("values")
-                .short('n')
-                .value_parser(value_parser!(usize))
-                .allow_negative_numbers(false)
-                .default_value("10")
-                .help("Specifies the number of output top-level values."),
+        command.with_input().with_output().with_format().arg(
+            Arg::new("no-auto-decompress")
+                .long("no-auto-decompress")
+                .action(ArgAction::SetTrue)
+                .help("Turn off automatic decompression detection."),
         )
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
-        //TODO: Multiple file handling in classic `head` includes a header per file.
-        // https://github.com/amazon-ion/ion-cli/issues/48
-
         // --format pretty|text|lines|binary
         // `clap` validates the specified format and provides a default otherwise.
         let format = args.get_one::<String>("format").unwrap();
@@ -60,31 +51,29 @@ impl IonCliCommand for HeadCommand {
             Box::new(stdout().lock())
         };
 
-        let num_values = *args.get_one::<usize>("values").unwrap();
-
         if let Some(input_file_iter) = args.get_many::<String>("input") {
             for input_file in input_file_iter {
                 let file = File::open(input_file)
                     .with_context(|| format!("Could not open file '{}'", input_file))?;
                 if let Some(true) = args.get_one::<bool>("no-auto-decompress") {
                     let mut reader = Reader::new(AnyEncoding, file)?;
-                    write_n_as(&mut reader, &mut output, format, num_values)?;
+                    write_all_as(&mut reader, &mut output, format)?;
                 } else {
                     let bfile = BufReader::with_capacity(BUF_READER_CAPACITY, file);
                     let zfile = auto_decompressing_reader(bfile, INFER_HEADER_LENGTH)?;
                     let mut reader = Reader::new(AnyEncoding, zfile)?;
-                    write_n_as(&mut reader, &mut output, format, num_values)?;
+                    write_all_as(&mut reader, &mut output, format)?;
                 };
             }
         } else {
             let input: StdinLock = stdin().lock();
             if let Some(true) = args.get_one::<bool>("no-auto-decompress") {
                 let mut reader = Reader::new(AnyEncoding, input)?;
-                write_n_as(&mut reader, &mut output, format, num_values)?;
+                write_all_as(&mut reader, &mut output, format)?;
             } else {
                 let zinput = auto_decompressing_reader(input, INFER_HEADER_LENGTH)?;
                 let mut reader = Reader::new(AnyEncoding, zinput)?;
-                write_n_as(&mut reader, &mut output, format, num_values)?;
+                write_all_as(&mut reader, &mut output, format)?;
             };
         }
 

--- a/src/bin/ion/commands/cat.rs
+++ b/src/bin/ion/commands/cat.rs
@@ -1,18 +1,11 @@
-use std::fs::File;
-use std::io::{stdin, stdout, BufReader, StdinLock, Write};
-
-use anyhow::{Context, Result};
-use clap::{Arg, ArgAction, ArgMatches, Command};
+use anyhow::Result;
+use clap::{ArgMatches, Command};
 use ion_rs::*;
 
-use crate::auto_decompress::auto_decompressing_reader;
-use crate::commands::{IonCliCommand, WithIonCliArgument};
+use crate::commands::{CommandIo, IonCliCommand, WithIonCliArgument};
 use crate::transcribe::write_all_as;
 
 pub struct CatCommand;
-
-const BUF_READER_CAPACITY: usize = 2 << 20; // 1 MiB
-const INFER_HEADER_LENGTH: usize = 8;
 
 impl IonCliCommand for CatCommand {
     fn name(&self) -> &'static str {
@@ -24,12 +17,11 @@ impl IonCliCommand for CatCommand {
     }
 
     fn configure_args(&self, command: Command) -> Command {
-        command.with_input().with_output().with_format().arg(
-            Arg::new("no-auto-decompress")
-                .long("no-auto-decompress")
-                .action(ArgAction::SetTrue)
-                .help("Turn off automatic decompression detection."),
-        )
+        command
+            .with_input()
+            .with_output()
+            .with_format()
+            .with_compression_control()
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
@@ -37,47 +29,10 @@ impl IonCliCommand for CatCommand {
         // `clap` validates the specified format and provides a default otherwise.
         let format = args.get_one::<String>("format").unwrap();
 
-        // -o filename
-        let mut output: Box<dyn Write> = if let Some(output_file) = args.get_one::<String>("output")
-        {
-            let file = File::create(output_file).with_context(|| {
-                format!(
-                    "could not open file output file '{}' for writing",
-                    output_file
-                )
-            })?;
-            Box::new(file)
-        } else {
-            Box::new(stdout().lock())
-        };
-
-        if let Some(input_file_iter) = args.get_many::<String>("input") {
-            for input_file in input_file_iter {
-                let file = File::open(input_file)
-                    .with_context(|| format!("Could not open file '{}'", input_file))?;
-                if let Some(true) = args.get_one::<bool>("no-auto-decompress") {
-                    let mut reader = Reader::new(AnyEncoding, file)?;
-                    write_all_as(&mut reader, &mut output, format)?;
-                } else {
-                    let bfile = BufReader::with_capacity(BUF_READER_CAPACITY, file);
-                    let zfile = auto_decompressing_reader(bfile, INFER_HEADER_LENGTH)?;
-                    let mut reader = Reader::new(AnyEncoding, zfile)?;
-                    write_all_as(&mut reader, &mut output, format)?;
-                };
-            }
-        } else {
-            let input: StdinLock = stdin().lock();
-            if let Some(true) = args.get_one::<bool>("no-auto-decompress") {
-                let mut reader = Reader::new(AnyEncoding, input)?;
-                write_all_as(&mut reader, &mut output, format)?;
-            } else {
-                let zinput = auto_decompressing_reader(input, INFER_HEADER_LENGTH)?;
-                let mut reader = Reader::new(AnyEncoding, zinput)?;
-                write_all_as(&mut reader, &mut output, format)?;
-            };
-        }
-
-        output.flush()?;
-        Ok(())
+        CommandIo::new(args).for_each_input(|output, input| {
+            let mut reader = Reader::new(AnyEncoding, input.into_source())?;
+            write_all_as(&mut reader, output, format)?;
+            Ok(())
+        })
     }
 }

--- a/src/bin/ion/commands/cat.rs
+++ b/src/bin/ion/commands/cat.rs
@@ -13,7 +13,7 @@ impl IonCliCommand for CatCommand {
     }
 
     fn about(&self) -> &'static str {
-        "Prints Ion in the requested format."
+        "Prints all Ion input files to the specified output in the requested format."
     }
 
     fn configure_args(&self, command: Command) -> Command {

--- a/src/bin/ion/commands/dump.rs
+++ b/src/bin/ion/commands/dump.rs
@@ -17,6 +17,10 @@ impl IonCliCommand for DumpCommand {
         "Deprecated alias for the `cat` command."
     }
 
+    fn hide_from_help_message(&self) -> bool {
+        true
+    }
+
     fn configure_args(&self, command: Command) -> Command {
         CatCommand.configure_args(command)
     }

--- a/src/bin/ion/commands/dump.rs
+++ b/src/bin/ion/commands/dump.rs
@@ -1,14 +1,12 @@
-use crate::commands::{IonCliCommand, WithIonCliArgument};
-use anyhow::{Context, Result};
-use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
-use ion_rs::*;
-use std::fs::File;
-use std::io::{self, stdin, stdout, BufRead, BufReader, Chain, Cursor, Read, StdinLock, Write};
+use anyhow::Result;
+use clap::{ArgMatches, Command};
 
+use crate::commands::cat::CatCommand;
+use crate::commands::IonCliCommand;
+
+// This command has been renamed to `cat` but is being preserved for the time being
+// for the sake of compatability with existing shell scripts.
 pub struct DumpCommand;
-
-const BUF_READER_CAPACITY: usize = 2 << 20; // 1 MiB
-const INFER_HEADER_LENGTH: usize = 8;
 
 impl IonCliCommand for DumpCommand {
     fn name(&self) -> &'static str {
@@ -16,223 +14,14 @@ impl IonCliCommand for DumpCommand {
     }
 
     fn about(&self) -> &'static str {
-        "Prints Ion in the requested format."
+        "Deprecated alias for the `cat` command."
     }
 
     fn configure_args(&self, command: Command) -> Command {
-        //TODO: Remove `values` after https://github.com/amazon-ion/ion-cli/issues/49
-        command
-            .arg(
-                Arg::new("values")
-                    .long("values")
-                    .short('n')
-                    .value_parser(value_parser!(usize))
-                    .allow_negative_numbers(false)
-                    .hide(true)
-                    .help("Specifies the number of output top-level values."),
-            )
-            .with_input()
-            .with_output()
-            .with_format()
-            .arg(
-                Arg::new("no-auto-decompress")
-                    .long("no-auto-decompress")
-                    .action(ArgAction::SetTrue)
-                    .help("Turn off automatic decompression detection."),
-            )
+        CatCommand.configure_args(command)
     }
 
-    fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
-        // --format pretty|text|lines|binary
-        // `clap` validates the specified format and provides a default otherwise.
-        let format = args.get_one::<String>("format").unwrap();
-
-        // --values <n>
-        // this value is supplied when `dump` is invoked as `head`
-        let values: Option<usize> = args.get_one::<usize>("values").copied();
-
-        // -o filename
-        let mut output: Box<dyn Write> = if let Some(output_file) = args.get_one::<String>("output")
-        {
-            let file = File::create(output_file).with_context(|| {
-                format!(
-                    "could not open file output file '{}' for writing",
-                    output_file
-                )
-            })?;
-            Box::new(file)
-        } else {
-            Box::new(stdout().lock())
-        };
-
-        if let Some(input_file_iter) = args.get_many::<String>("input") {
-            for input_file in input_file_iter {
-                let file = File::open(input_file)
-                    .with_context(|| format!("Could not open file '{}'", input_file))?;
-                if let Some(true) = args.get_one::<bool>("no-auto-decompress") {
-                    let mut reader = Reader::new(AnyEncoding, file)?;
-                    write_in_format(&mut reader, &mut output, format, values)?;
-                } else {
-                    let bfile = BufReader::with_capacity(BUF_READER_CAPACITY, file);
-                    let zfile = auto_decompressing_reader(bfile, INFER_HEADER_LENGTH)?;
-                    let mut reader = Reader::new(AnyEncoding, zfile)?;
-                    write_in_format(&mut reader, &mut output, format, values)?;
-                };
-            }
-        } else {
-            let input: StdinLock = stdin().lock();
-            if let Some(true) = args.get_one::<bool>("no-auto-decompress") {
-                let mut reader = Reader::new(AnyEncoding, input)?;
-                write_in_format(&mut reader, &mut output, format, values)?;
-            } else {
-                let zinput = auto_decompressing_reader(input, INFER_HEADER_LENGTH)?;
-                let mut reader = Reader::new(AnyEncoding, zinput)?;
-                write_in_format(&mut reader, &mut output, format, values)?;
-            };
-        }
-
-        output.flush()?;
-        Ok(())
+    fn run(&self, command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
+        CatCommand.run(command_path, args)
     }
-}
-
-// TODO: This is a compatibility shim. Several commands refer to dump::run(); that functionality
-//       now lives in `dump`'s implementation of the IonCliCommand trait. These referents should
-//       be updated to refer to functionality in a common module so this can be removed.
-//       See: https://github.com/amazon-ion/ion-cli/issues/49
-pub(crate) fn run(_command: &str, args: &ArgMatches) -> Result<()> {
-    DumpCommand.run(&mut Vec::new(), args)
-}
-
-/// Constructs the appropriate writer for the given format, then writes all values found in the
-/// Reader to the new Writer. If `count` is specified will write at most `count` values.
-pub(crate) fn write_in_format<I: IonInput>(
-    reader: &mut Reader<AnyEncoding, I>,
-    output: &mut Box<dyn Write>,
-    format: &str,
-    count: Option<usize>,
-) -> IonResult<usize> {
-    let written = match format {
-        "pretty" => {
-            let mut writer = Writer::new(v1_0::Text.with_format(TextFormat::Pretty), output)?;
-            transcribe_n_values(reader, &mut writer, count)
-        }
-        "text" => {
-            let mut writer = Writer::new(v1_0::Text.with_format(TextFormat::Compact), output)?;
-            transcribe_n_values(reader, &mut writer, count)
-        }
-        "lines" => {
-            let mut writer = Writer::new(v1_0::Text.with_format(TextFormat::Lines), output)?;
-            transcribe_n_values(reader, &mut writer, count)
-        }
-        "binary" => {
-            let mut writer = Writer::new(v1_0::Binary, output)?;
-            transcribe_n_values(reader, &mut writer, count)
-        }
-        unrecognized => unreachable!(
-            "'format' was '{}' instead of 'pretty', 'text', 'lines', or 'binary'",
-            unrecognized
-        ),
-    }?;
-    Ok(written)
-}
-
-/// Writes each value encountered in the Reader to the provided IonWriter. If `count` is specified
-/// will write at most `count` values.
-fn transcribe_n_values<I: IonInput, E: Encoding>(
-    reader: &mut Reader<AnyEncoding, I>,
-    writer: &mut Writer<E, &mut Box<dyn Write>>,
-    count: Option<usize>,
-) -> IonResult<usize> {
-    const FLUSH_EVERY_N: usize = 100;
-    let mut values_since_flush: usize = 0;
-    let max_items = count.unwrap_or(usize::MAX);
-    let mut index: usize = 0;
-
-    while let Some(value) = reader.next()? {
-        if index >= max_items {
-            break;
-        }
-
-        writer.write(value)?;
-
-        index += 1;
-        values_since_flush += 1;
-        if values_since_flush == FLUSH_EVERY_N {
-            writer.flush()?;
-            values_since_flush = 0;
-        }
-    }
-
-    writer.flush()?;
-    Ok(index)
-}
-
-/// Auto-detects a compressed byte stream and wraps the original reader
-/// into a reader that transparently decompresses.
-///
-/// To support non-seekable readers like `Stdin`, we could have used a
-/// full-blown buffering wrapper with unlimited rewinds, but since we only
-/// need the first few magic bytes at offset 0, we cheat and instead make a
-/// `Chain` reader from the buffered header followed by the original reader.
-///
-/// The choice of `Chain` type here is not quite necessary: it could have
-/// been simply `dyn BufRead`, but there is no `ToIonDataSource` trait
-/// implementation for `dyn BufRead` at the moment.
-type AutoDecompressingReader = Chain<Box<dyn BufRead>, Box<dyn BufRead>>;
-
-fn auto_decompressing_reader<R>(
-    mut reader: R,
-    header_len: usize,
-) -> IonResult<AutoDecompressingReader>
-where
-    R: BufRead + 'static,
-{
-    // read header
-    let mut header_bytes = vec![0; header_len];
-    let nread = read_reliably(&mut reader, &mut header_bytes)?;
-    header_bytes.truncate(nread);
-
-    // detect compression type and wrap reader in a decompressor
-    match infer::get(&header_bytes) {
-        Some(t) => match t.extension() {
-            "gz" => {
-                // "rewind" to let the decompressor read magic bytes again
-                let header: Box<dyn BufRead> = Box::new(Cursor::new(header_bytes));
-                let chain = header.chain(reader);
-                let zreader = Box::new(BufReader::new(flate2::read::GzDecoder::new(chain)));
-                // must return a `Chain`, so prepend an empty buffer
-                let nothing: Box<dyn BufRead> = Box::new(Cursor::new(&[] as &[u8]));
-                Ok(nothing.chain(zreader))
-            }
-            "zst" => {
-                let header: Box<dyn BufRead> = Box::new(Cursor::new(header_bytes));
-                let chain = header.chain(reader);
-                let zreader = Box::new(BufReader::new(zstd::stream::read::Decoder::new(chain)?));
-                let nothing: Box<dyn BufRead> = Box::new(Cursor::new(&[] as &[u8]));
-                Ok(nothing.chain(zreader))
-            }
-            _ => {
-                let header: Box<dyn BufRead> = Box::new(Cursor::new(header_bytes));
-                Ok(header.chain(Box::new(reader)))
-            }
-        },
-        None => {
-            let header: Box<dyn BufRead> = Box::new(Cursor::new(header_bytes));
-            Ok(header.chain(Box::new(reader)))
-        }
-    }
-}
-
-/// same as `Read` trait's read() method, but loops in case of fragmented reads
-fn read_reliably<R: Read>(reader: &mut R, buf: &mut [u8]) -> io::Result<usize> {
-    let mut nread = 0;
-    while nread < buf.len() {
-        match reader.read(&mut buf[nread..]) {
-            Ok(0) => break,
-            Ok(n) => nread += n,
-            Err(e) => return Err(e),
-        }
-    }
-    Ok(nread)
 }

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -25,6 +25,14 @@ pub trait IonCliCommand {
     /// A brief message describing this command's functionality.
     fn about(&self) -> &'static str;
 
+    /// If `true`, prevents this command from showing up in the parent namespace's help message.
+    /// This can be helpful for deprecating names while still supporting the old alias
+    ///
+    /// Defaults to `false`.
+    fn hide_from_help_message(&self) -> bool {
+        false
+    }
+
     /// Initializes a [`ClapCommand`] representing this command and its subcommands (if any).
     ///
     /// Commands wishing to customize their `ClapCommand`'s arguments should override
@@ -42,7 +50,8 @@ pub trait IonCliCommand {
         let mut base_command = ClapCommand::new(self.name())
             .about(self.about())
             .version(crate_version!())
-            .author(crate_authors!());
+            .author(crate_authors!())
+            .hide(self.hide_from_help_message());
 
         // If there are subcommands, add them to the configuration and set 'subcommand_required'.
         if !clap_subcommands.is_empty() {

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -1,5 +1,12 @@
-use anyhow::anyhow;
+use crate::file_writer::FileWriter;
+use crate::input::CommandInput;
+use crate::output::CommandOutput;
+use anyhow::Result;
+use anyhow::{anyhow, Context};
 use clap::{crate_authors, crate_version, Arg, ArgAction, ArgMatches, Command as ClapCommand};
+use std::fs::File;
+use std::io::Write;
+use termcolor::{ColorChoice, StandardStream, StandardStreamLock};
 
 pub mod beta;
 pub mod cat;
@@ -103,6 +110,7 @@ pub trait WithIonCliArgument {
     fn with_input(self) -> Self;
     fn with_output(self) -> Self;
     fn with_format(self) -> Self;
+    fn with_compression_control(self) -> Self;
 }
 
 impl WithIonCliArgument for ClapCommand {
@@ -134,5 +142,91 @@ impl WithIonCliArgument for ClapCommand {
                 .value_parser(["binary", "text", "pretty", "lines"])
                 .help("Output format"),
         )
+    }
+
+    fn with_compression_control(self) -> Self {
+        self.arg(
+            Arg::new("no-auto-decompress")
+                .long("no-auto-decompress")
+                .action(ArgAction::SetTrue)
+                .help("Turn off automatic decompression detection."),
+        )
+    }
+}
+
+pub struct CommandIo<'a> {
+    args: &'a ArgMatches,
+}
+
+impl<'a> CommandIo<'a> {
+    fn new(args: &ArgMatches) -> CommandIo {
+        CommandIo { args }
+    }
+
+    fn auto_decompression_enabled(&self) -> bool {
+        if let Some(flag) = self.args.get_one::<bool>("no-auto-decompress") {
+            !*flag
+        } else {
+            true
+        }
+    }
+
+    fn command_input_for_stdin(&self) -> Result<CommandInput> {
+        const STDIN_NAME: &str = "-";
+        let stdin = std::io::stdin().lock();
+        if self.auto_decompression_enabled() {
+            CommandInput::decompress(STDIN_NAME, stdin)
+        } else {
+            CommandInput::new(STDIN_NAME, stdin)
+        }
+    }
+
+    fn command_input_for_file_name(&self, name: &str) -> Result<CommandInput> {
+        let stream = File::open(name)?;
+        if self.auto_decompression_enabled() {
+            CommandInput::decompress(name, stream)
+        } else {
+            CommandInput::new(name, stream)
+        }
+    }
+
+    fn for_each_input(
+        &mut self,
+        mut f: impl FnMut(&mut CommandOutput, CommandInput) -> Result<()>,
+    ) -> Result<()> {
+        // These types are provided by the `termcolor` crate. They wrap the normal `io::Stdout` and
+        // `io::StdOutLock` types, making it possible to write colorful text to the output stream when
+        // it's a TTY that understands formatting escape codes. These variables are declared here so
+        // the lifetime will extend through the remainder of the function. Unlike `io::StdoutLock`,
+        // the `StandardStreamLock` does not have a static lifetime.
+        let stdout: StandardStream;
+        let stdout_lock: StandardStreamLock;
+        let mut output = if let Some(output_file) = self.args.get_one::<String>("output") {
+            // If the user has specified an output file, use it.
+            let file = File::create(output_file).with_context(|| {
+                format!(
+                    "could not open file output file '{}' for writing",
+                    output_file
+                )
+            })?;
+            CommandOutput::File(FileWriter::new(file))
+        } else {
+            // Otherwise, write to STDOUT.
+            stdout = StandardStream::stdout(ColorChoice::Always);
+            stdout_lock = stdout.lock();
+            CommandOutput::StdOut(stdout_lock)
+        };
+        if let Some(input_file_names) = self.args.get_many::<String>("input") {
+            // Input files were specified, run the converter on each of them in turn
+            for input_file_name in input_file_names {
+                let input = self.command_input_for_file_name(input_file_name)?;
+                f(&mut output, input)?;
+            }
+        } else {
+            let input = self.command_input_for_stdin()?;
+            f(&mut output, input)?;
+        }
+        output.flush()?;
+        Ok(())
     }
 }

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -154,6 +154,7 @@ impl WithIonCliArgument for ClapCommand {
     }
 }
 
+/// Offers convenience methods for working with input and output streams.
 pub struct CommandIo<'a> {
     args: &'a ArgMatches,
 }
@@ -163,6 +164,7 @@ impl<'a> CommandIo<'a> {
         CommandIo { args }
     }
 
+    /// Returns `true` if the user has not explicitly disabled auto decompression.
     fn auto_decompression_enabled(&self) -> bool {
         if let Some(flag) = self.args.get_one::<bool>("no-auto-decompress") {
             !*flag
@@ -171,6 +173,7 @@ impl<'a> CommandIo<'a> {
         }
     }
 
+    /// Constructs a new [`CommandInput`] representing STDIN.
     fn command_input_for_stdin(&self) -> Result<CommandInput> {
         const STDIN_NAME: &str = "-";
         let stdin = std::io::stdin().lock();
@@ -181,6 +184,7 @@ impl<'a> CommandIo<'a> {
         }
     }
 
+    /// Constructs a new [`CommandInput`] representing the specified file.
     fn command_input_for_file_name(&self, name: &str) -> Result<CommandInput> {
         let stream = File::open(name)?;
         if self.auto_decompression_enabled() {
@@ -190,6 +194,8 @@ impl<'a> CommandIo<'a> {
         }
     }
 
+    /// Calls the provided closure once for each input source specified by the user.
+    /// For each invocation, provides a handle to the configured output stream.
     fn for_each_input(
         &mut self,
         mut f: impl FnMut(&mut CommandOutput, CommandInput) -> Result<()>,

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -189,7 +189,7 @@ impl<'a> CommandIo<'a> {
         if self.auto_decompression_enabled() {
             CommandInput::decompress(STDIN_NAME, stdin)
         } else {
-            CommandInput::new(STDIN_NAME, stdin)
+            CommandInput::without_decompression(STDIN_NAME, stdin)
         }
     }
 
@@ -199,7 +199,7 @@ impl<'a> CommandIo<'a> {
         if self.auto_decompression_enabled() {
             CommandInput::decompress(name, stream)
         } else {
-            CommandInput::new(name, stream)
+            CommandInput::without_decompression(name, stream)
         }
     }
 

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -2,6 +2,7 @@ use anyhow::anyhow;
 use clap::{crate_authors, crate_version, Arg, ArgAction, ArgMatches, Command as ClapCommand};
 
 pub mod beta;
+pub mod cat;
 pub mod dump;
 pub mod inspect;
 

--- a/src/bin/ion/input.rs
+++ b/src/bin/ion/input.rs
@@ -40,7 +40,10 @@ impl CommandInput {
 
     /// Constructs a new [`CommandInput`] that streams data from `source` without attempting to
     /// decompress its data.
-    pub fn without_decompression(name: impl Into<String>, source: impl Read + 'static) -> Result<CommandInput> {
+    pub fn without_decompression(
+        name: impl Into<String>,
+        source: impl Read + 'static,
+    ) -> Result<CommandInput> {
         Ok(Self {
             source: BufReader::new(Box::new(source)),
             name: name.into(),

--- a/src/bin/ion/input.rs
+++ b/src/bin/ion/input.rs
@@ -2,9 +2,13 @@ use crate::auto_decompress::{decompress, AutoDecompressingReader};
 use anyhow::Result;
 use std::io::{BufReader, Read};
 
+// The number of header bytes to inspect with the `infer` crate to detect compression.
 const INFER_HEADER_LENGTH: usize = 8;
 
+/// The compression codec detected at the head of the input stream.
 pub enum CompressionDetected {
+    // Note that `None` may indicate either that compression detection was disabled OR that the
+    // input stream did not begin with a compression identifier that the Ion CLI supports.
     None,
     Gzip,
     Zstd,
@@ -41,11 +45,15 @@ impl CommandInput {
     }
 
     // TODO: Implement IonInput for mutable references to an impl Read
-    //       For now, creating a `Reader` requires that we hand over the entire BufReader
+    //       For now, creating a `Reader` requires that we hand over the entire BufReader.
+    //       See: https://github.com/amazon-ion/ion-rust/issues/783
     pub fn into_source(self) -> AutoDecompressingReader {
         self.source
     }
 
+    /// Returns either:
+    /// * the name of the input file that this `CommandInput` represents
+    /// * the string `"-"` if this `CommandInput` represents STDIN.
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/src/bin/ion/input.rs
+++ b/src/bin/ion/input.rs
@@ -1,0 +1,59 @@
+use crate::auto_decompress::{decompress, AutoDecompressingReader};
+use anyhow::Result;
+use std::io::{BufReader, Read};
+
+const INFER_HEADER_LENGTH: usize = 8;
+
+pub enum CompressionDetected {
+    None,
+    Gzip,
+    Zstd,
+}
+
+pub struct CommandInput {
+    source: AutoDecompressingReader,
+    name: String,
+    #[allow(dead_code)]
+    // This field is retained so commands can print debug information about the input source.
+    // It is not currently used, which generates a compile warning.
+    compression: CompressionDetected,
+}
+
+impl CommandInput {
+    pub fn new(name: impl Into<String>, source: impl Read + 'static) -> Result<CommandInput> {
+        Ok(Self {
+            source: BufReader::new(Box::new(source)),
+            name: name.into(),
+            compression: CompressionDetected::None,
+        })
+    }
+
+    pub fn decompress(
+        name: impl Into<String>,
+        source: impl Read + 'static,
+    ) -> Result<CommandInput> {
+        let (compression, decompressed) = decompress(source, INFER_HEADER_LENGTH)?;
+        Ok(Self {
+            source: decompressed,
+            name: name.into(),
+            compression,
+        })
+    }
+
+    // TODO: Implement IonInput for mutable references to an impl Read
+    //       For now, creating a `Reader` requires that we hand over the entire BufReader
+    pub fn into_source(self) -> AutoDecompressingReader {
+        self.source
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[allow(dead_code)]
+    // This field is retained so commands can print debug information about the input source.
+    // It is not currently used, which generates a compile warning.
+    pub fn compression(&self) -> &CompressionDetected {
+        &self.compression
+    }
+}

--- a/src/bin/ion/input.rs
+++ b/src/bin/ion/input.rs
@@ -24,14 +24,8 @@ pub struct CommandInput {
 }
 
 impl CommandInput {
-    pub fn new(name: impl Into<String>, source: impl Read + 'static) -> Result<CommandInput> {
-        Ok(Self {
-            source: BufReader::new(Box::new(source)),
-            name: name.into(),
-            compression: CompressionDetected::None,
-        })
-    }
-
+    /// Performs compression detection on the provided data source and returns a new [`CommandInput`]
+    /// that will decompress its bytes in a streaming fashion.
     pub fn decompress(
         name: impl Into<String>,
         source: impl Read + 'static,
@@ -41,6 +35,16 @@ impl CommandInput {
             source: decompressed,
             name: name.into(),
             compression,
+        })
+    }
+
+    /// Constructs a new [`CommandInput`] that streams data from `source` without attempting to
+    /// decompress its data.
+    pub fn without_decompression(name: impl Into<String>, source: impl Read + 'static) -> Result<CommandInput> {
+        Ok(Self {
+            source: BufReader::new(Box::new(source)),
+            name: name.into(),
+            compression: CompressionDetected::None,
         })
     }
 

--- a/src/bin/ion/main.rs
+++ b/src/bin/ion/main.rs
@@ -1,6 +1,8 @@
 mod auto_decompress;
 mod commands;
 mod file_writer;
+mod input;
+mod output;
 mod transcribe;
 
 use crate::commands::beta::BetaNamespace;

--- a/src/bin/ion/main.rs
+++ b/src/bin/ion/main.rs
@@ -1,7 +1,10 @@
+mod auto_decompress;
 mod commands;
 mod file_writer;
+mod transcribe;
 
 use crate::commands::beta::BetaNamespace;
+use crate::commands::cat::CatCommand;
 use anyhow::Result;
 use commands::IonCliCommand;
 use ion_rs::IonError;
@@ -44,6 +47,7 @@ impl IonCliCommand for RootCommand {
         vec![
             Box::new(BetaNamespace),
             Box::new(DumpCommand),
+            Box::new(CatCommand),
             Box::new(InspectCommand),
         ]
     }

--- a/src/bin/ion/output.rs
+++ b/src/bin/ion/output.rs
@@ -1,0 +1,52 @@
+use crate::file_writer::FileWriter;
+use std::io::Write;
+use termcolor::{ColorSpec, StandardStreamLock, WriteColor};
+
+pub enum CommandOutput<'a> {
+    StdOut(StandardStreamLock<'a>),
+    File(FileWriter),
+}
+
+impl<'a> Write for CommandOutput<'a> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        use CommandOutput::*;
+        match self {
+            StdOut(stdout) => stdout.write(buf),
+            File(file_writer) => file_writer.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        use CommandOutput::*;
+        match self {
+            StdOut(stdout) => stdout.flush(),
+            File(file_writer) => file_writer.flush(),
+        }
+    }
+}
+
+impl<'a> WriteColor for CommandOutput<'a> {
+    fn supports_color(&self) -> bool {
+        use CommandOutput::*;
+        match self {
+            StdOut(stdout) => stdout.supports_color(),
+            File(file_writer) => file_writer.supports_color(),
+        }
+    }
+
+    fn set_color(&mut self, spec: &ColorSpec) -> std::io::Result<()> {
+        use CommandOutput::*;
+        match self {
+            StdOut(stdout) => stdout.set_color(spec),
+            File(file_writer) => file_writer.set_color(spec),
+        }
+    }
+
+    fn reset(&mut self) -> std::io::Result<()> {
+        use CommandOutput::*;
+        match self {
+            StdOut(stdout) => stdout.reset(),
+            File(file_writer) => file_writer.reset(),
+        }
+    }
+}

--- a/src/bin/ion/output.rs
+++ b/src/bin/ion/output.rs
@@ -2,6 +2,8 @@ use crate::file_writer::FileWriter;
 use std::io::Write;
 use termcolor::{ColorSpec, StandardStreamLock, WriteColor};
 
+/// Statically dispatches writes to either an output file or STDOUT while also supporting `termcolor`
+/// style escape sequences when the target is a TTY.
 pub enum CommandOutput<'a> {
     StdOut(StandardStreamLock<'a>),
     File(FileWriter),

--- a/src/bin/ion/transcribe.rs
+++ b/src/bin/ion/transcribe.rs
@@ -1,0 +1,72 @@
+use anyhow::{bail, Result};
+use ion_rs::*;
+use std::io::Write;
+
+/// Constructs the appropriate writer for the given format, then writes all values from the
+/// `Reader` to the new `Writer`.
+pub(crate) fn write_all_as<I: IonInput>(
+    reader: &mut Reader<AnyEncoding, I>,
+    output: &mut impl Write,
+    format: &str,
+) -> Result<usize> {
+    write_n_as(reader, output, format, usize::MAX)
+}
+
+/// Constructs the appropriate writer for the given format, then writes up to `count` values from the
+/// `Reader` to the new `Writer`.
+pub(crate) fn write_n_as<I: IonInput>(
+    reader: &mut Reader<AnyEncoding, I>,
+    output: &mut impl Write,
+    format: &str,
+    count: usize,
+) -> Result<usize> {
+    let written = match format {
+        "pretty" => {
+            let mut writer = Writer::new(v1_0::Text.with_format(TextFormat::Pretty), output)?;
+            transcribe_n(reader, &mut writer, count)
+        }
+        "text" => {
+            let mut writer = Writer::new(v1_0::Text.with_format(TextFormat::Compact), output)?;
+            transcribe_n(reader, &mut writer, count)
+        }
+        "lines" => {
+            let mut writer = Writer::new(v1_0::Text.with_format(TextFormat::Lines), output)?;
+            transcribe_n(reader, &mut writer, count)
+        }
+        "binary" => {
+            let mut writer = Writer::new(v1_0::Binary, output)?;
+            transcribe_n(reader, &mut writer, count)
+        }
+        unrecognized => bail!("unsupported format '{unrecognized}'"),
+    }?;
+    Ok(written)
+}
+
+/// Writes up to `count` values from the `Reader` to the provided `Writer`.
+fn transcribe_n(
+    reader: &mut Reader<impl Decoder, impl IonInput>,
+    writer: &mut Writer<impl Encoding, impl Write>,
+    count: usize,
+) -> Result<usize> {
+    const FLUSH_EVERY_N: usize = 100;
+    let mut values_since_flush: usize = 0;
+    let mut index: usize = 0;
+
+    while let Some(value) = reader.next()? {
+        if index >= count {
+            break;
+        }
+
+        writer.write(value)?;
+
+        index += 1;
+        values_since_flush += 1;
+        if values_since_flush == FLUSH_EVERY_N {
+            writer.flush()?;
+            values_since_flush = 0;
+        }
+    }
+
+    writer.flush()?;
+    Ok(index)
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -171,35 +171,6 @@ fn run_it<S: AsRef<str>>(
     Ok(())
 }
 
-#[test]
-fn gogogo() -> Result<()> {
-    let ion = r#"
-{
-  name: "Fido",
-
-  age: years::4,
-
-  birthday: 2012-03-01T,
-
-  toys: [
-    ball,
-    rope,
-  ],
-
-  weight: pounds::41.2,
-
-  buzz: {{VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE=}},
-}
-"#;
-    run_it(
-        TestCase::from((ion, ion)),
-        "pretty",
-        FileMode::Named,
-        FileMode::Named,
-        InputCompress::Gz,
-    )
-}
-
 #[rstest]
 #[case(0, "")]
 #[case(2, "{foo: bar, abc: [123, 456]}\n{foo: baz, abc: [42.0, 4.3e1]}")]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -171,6 +171,35 @@ fn run_it<S: AsRef<str>>(
     Ok(())
 }
 
+#[test]
+fn gogogo() -> Result<()> {
+    let ion = r#"
+{
+  name: "Fido",
+
+  age: years::4,
+
+  birthday: 2012-03-01T,
+
+  toys: [
+    ball,
+    rope,
+  ],
+
+  weight: pounds::41.2,
+
+  buzz: {{VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE=}},
+}
+"#;
+    run_it(
+        TestCase::from((ion, ion)),
+        "pretty",
+        FileMode::Named,
+        FileMode::Named,
+        InputCompress::Gz,
+    )
+}
+
 #[rstest]
 #[case(0, "")]
 #[case(2, "{foo: bar, abc: [123, 456]}\n{foo: baz, abc: [42.0, 4.3e1]}")]


### PR DESCRIPTION
### Issue #, if available: #49, #55

-----

This PR introduces a `CommandIo` type that provides a centralized implementation of input and output file/stream setup. Individual commands are no longer responsible for detecting I/O errors, configuring decompression, or setting up `termcolor`'s output streams.

It also:
* Makes `dump` a deprecated alias for the command's new name: `cat`.
* Factors out the transcription logic shared by both `head` and `cat`.
* Adds a `CommandInput` type that remembers the name of the input stream and what type of compression it detected.
* Adds a `CommandOutput` type that statically dispatches over `File`/`StdOut` and supports `termcolor`.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
