### PR TITLE
Adds support for struct with both `type` and `fields` constraint

### DIFF
--- a/code-gen-projects/schema/nested_struct.isl
+++ b/code-gen-projects/schema/nested_struct.isl
@@ -1,9 +1,11 @@
 type::{
  name: nested_struct,
+ type: struct,
  fields: {
     A: string,
     B: int,
     C: {
+        type: struct,
         fields: {
             D: bool,
             E: { type: list, element: int }

--- a/code-gen-projects/schema/struct_with_fields.isl
+++ b/code-gen-projects/schema/struct_with_fields.isl
@@ -1,5 +1,6 @@
 type::{
  name: struct_with_fields,
+ type: struct,
  fields: {
     A: string,
     B: int,

--- a/src/bin/ion/commands/beta/generate/context.rs
+++ b/src/bin/ion/commands/beta/generate/context.rs
@@ -95,6 +95,13 @@ impl AbstractDataType {
             _ => None,
         }
     }
+
+    pub fn is_content_closed(&self) -> Option<bool> {
+        match self {
+            AbstractDataType::Structure(content_closed) => Some(*content_closed),
+            _ => None
+        }
+    }
 }
 
 impl Display for AbstractDataType {

--- a/src/bin/ion/commands/beta/generate/context.rs
+++ b/src/bin/ion/commands/beta/generate/context.rs
@@ -99,7 +99,7 @@ impl AbstractDataType {
     pub fn is_content_closed(&self) -> Option<bool> {
         match self {
             AbstractDataType::Structure(content_closed) => Some(*content_closed),
-            _ => None
+            _ => None,
         }
     }
 }

--- a/src/bin/ion/commands/beta/generate/generator.rs
+++ b/src/bin/ion/commands/beta/generate/generator.rs
@@ -283,7 +283,7 @@ impl<'a, L: Language + 'static> CodeGenerator<'a, L> {
             .any(|Field { value_type, .. }| value_type.is_none())
         {
             return invalid_abstract_data_type_error("Currently code generation does not support open ended types. \
-            Error can be due to a missing `type` constraint or `element` constraint in the type definition.");
+            Error can be due to a missing `type` or `fields` or `element` constraint in the type definition.");
         }
 
         // add fields for template
@@ -436,6 +436,8 @@ impl<'a, L: Language + 'static> CodeGenerator<'a, L> {
                             element_type: type_name.clone(),
                             sequence_type: Some(SequenceType::SExp),
                         }
+                    } else if isl_type.name() == "struct" {
+                        AbstractDataType::Structure(false) // by default contents aren't closed
                     } else {
                         AbstractDataType::Value
                     },
@@ -570,6 +572,29 @@ impl<'a, L: Language + 'static> CodeGenerator<'a, L> {
                         element_type: element_type.to_owned(),
                         sequence_type: current_abstract_data_type.sequence_type(),
                     })
+                }
+                // In the case when a `type` constraint occurs before `fields` constraint. The `content_closed` property for the struct
+                // needs to be updated based on `fields` constraint.
+                // e.g. For a schema as below:
+                // ```
+                // type::{
+                //   name: struct_type,
+                //   type: struct,
+                //   fields: {}
+                //      foo: string
+                //   },
+                // }
+                // ```
+                // Here, first `type` constraint would set tera_fields with `value_type: None` and with `fields` constraint this field should be popped,
+                // and modify the `content_closed` property as per `fields` constraint.
+                AbstractDataType::Structure(_) if !tera_fields.is_empty() && tera_fields[0].value_type.is_none()
+                    && matches!(
+                        &current_abstract_data_type,
+                        &AbstractDataType::Structure(_)
+                    ) => {
+                    tera_fields.pop();
+                    // unwrap here is safe because we know the current_abstract_data_type is a `Structure`
+                    code_gen_context.with_abstract_data_type(AbstractDataType::Structure(current_abstract_data_type.is_content_closed().unwrap()))
                 }
                 _ if abstract_data_type != &current_abstract_data_type => {
                     return invalid_abstract_data_type_error(format!("Can not determine abstract data type as current constraint {} conflicts with prior constraints for {}.", current_abstract_data_type, abstract_data_type));

--- a/src/bin/ion/commands/beta/generate/generator.rs
+++ b/src/bin/ion/commands/beta/generate/generator.rs
@@ -587,14 +587,19 @@ impl<'a, L: Language + 'static> CodeGenerator<'a, L> {
                 // ```
                 // Here, first `type` constraint would set tera_fields with `value_type: None` and with `fields` constraint this field should be popped,
                 // and modify the `content_closed` property as per `fields` constraint.
-                AbstractDataType::Structure(_) if !tera_fields.is_empty() && tera_fields[0].value_type.is_none()
-                    && matches!(
-                        &current_abstract_data_type,
-                        &AbstractDataType::Structure(_)
-                    ) => {
+                AbstractDataType::Structure(_)
+                    if !tera_fields.is_empty()
+                        && tera_fields[0].value_type.is_none()
+                        && matches!(
+                            &current_abstract_data_type,
+                            &AbstractDataType::Structure(_)
+                        ) =>
+                {
                     tera_fields.pop();
                     // unwrap here is safe because we know the current_abstract_data_type is a `Structure`
-                    code_gen_context.with_abstract_data_type(AbstractDataType::Structure(current_abstract_data_type.is_content_closed().unwrap()))
+                    code_gen_context.with_abstract_data_type(AbstractDataType::Structure(
+                        current_abstract_data_type.is_content_closed().unwrap(),
+                    ))
                 }
                 _ if abstract_data_type != &current_abstract_data_type => {
                     return invalid_abstract_data_type_error(format!("Can not determine abstract data type as current constraint {} conflicts with prior constraints for {}.", current_abstract_data_type, abstract_data_type));

--- a/src/bin/ion/commands/beta/generate/utils.rs
+++ b/src/bin/ion/commands/beta/generate/utils.rs
@@ -102,7 +102,7 @@ impl Language for JavaLanguage {
                 Float => "double",
                 Bool => "boolean",
                 Blob | Clob => "byte[]",
-                List | SExp => return None,
+                List | SExp | Struct => return None,
                 SchemaDefined(name) => name,
             }
             .to_string(),
@@ -178,7 +178,7 @@ impl Language for RustLanguage {
                 Float => "f64",
                 Bool => "bool",
                 Blob | Clob => "Vec<u8>",
-                List | SExp => return None,
+                List | SExp| Struct => return None,
                 SchemaDefined(name) => name,
             }
             .to_string(),
@@ -249,6 +249,7 @@ pub enum IonSchemaType {
     Clob,
     SExp,
     List,
+    Struct,
     SchemaDefined(String), // A user defined schema type
 }
 
@@ -273,7 +274,7 @@ impl From<&str> for IonSchemaType {
                 unimplemented!("Decimal, Number and Timestamp aren't support yet!")
             }
             "struct" => {
-                unimplemented!("Generic containers aren't supported yet!")
+                Struct
             }
             "list" => List,
             "sexp" => SExp,

--- a/src/bin/ion/commands/beta/generate/utils.rs
+++ b/src/bin/ion/commands/beta/generate/utils.rs
@@ -178,7 +178,7 @@ impl Language for RustLanguage {
                 Float => "f64",
                 Bool => "bool",
                 Blob | Clob => "Vec<u8>",
-                List | SExp| Struct => return None,
+                List | SExp | Struct => return None,
                 SchemaDefined(name) => name,
             }
             .to_string(),
@@ -273,9 +273,7 @@ impl From<&str> for IonSchemaType {
             "decimal" | "timestamp" => {
                 unimplemented!("Decimal, Number and Timestamp aren't support yet!")
             }
-            "struct" => {
-                Struct
-            }
+            "struct" => Struct,
             "list" => List,
             "sexp" => SExp,
             _ => SchemaDefined(value.to_case(Case::UpperCamel)),

--- a/tests/code-gen-tests.rs
+++ b/tests/code-gen-tests.rs
@@ -107,6 +107,15 @@ r#"
         }
     "#
 )]
+// Currently any struct type is not supported, it requires having a `fields` constraint
+#[case::any_struct_type(
+    r#"
+        type::{
+         name: any_struct_type,
+         type: struct, // this doesn't specify `fields` of the struct
+        }
+    "#
+)]
 /// Calls ion-cli beta generate with different unsupported schema types. Verify that `generate` subcommand returns an error for these schema types.
 fn test_unsupported_schema_types_failures(#[case] test_schema: &str) -> Result<()> {
     let mut cmd = Command::cargo_bin("ion")?;


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
This PR works on adding support for struct with both `type` and `fields` constraint.

### List of changes:
- Modified `map_constraint_to_abstract_data_type` to add support for `type: struct`.
- Currently implementation returns an error if only `type: struct` was used without `fields` constraints.
- Generated code remains same as per `fields` constraint.
 
### Tests:
Modified current tests and add an invalid test case for only `type:struct` constraint inside a type def.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
