### PR TITLE
Adds template resources as constants

### DIFF
--- a/src/bin/ion/commands/beta/generate/generator.rs
+++ b/src/bin/ion/commands/beta/generate/generator.rs
@@ -37,12 +37,13 @@ impl<'a> CodeGenerator<'a, RustLanguage> {
         let mut tera = Tera::default();
         // Add all templates using `rust_templates` module constants
         // This allows packaging binary without the need of template resources.
-        let _ = tera.add_raw_templates(vec![
+        tera.add_raw_templates(vec![
             ("struct.templ", templates::rust::STRUCT),
             ("import.templ", templates::rust::IMPORT),
             ("nested_type.templ", templates::rust::NESTED_TYPE),
             ("result.templ", templates::rust::RESULT),
-        ]);
+        ])
+        .unwrap();
         // Render the imports into output file
         let rendered_import = tera.render("import.templ", &Context::new()).unwrap();
         // Render the SerdeResult that is used in generated read-write APIs
@@ -74,10 +75,11 @@ impl<'a> CodeGenerator<'a, JavaLanguage> {
         let mut tera = Tera::default();
         // Add all templates using `java_templates` module constants
         // This allows packaging binary without the need of template resources.
-        let _ = tera.add_raw_templates(vec![
+        tera.add_raw_templates(vec![
             ("class.templ", templates::java::CLASS),
             ("nested_type.templ", templates::java::NESTED_TYPE),
-        ]);
+        ])
+        .unwrap();
         Self {
             output,
             namespace: Some(namespace),

--- a/src/bin/ion/commands/beta/generate/mod.rs
+++ b/src/bin/ion/commands/beta/generate/mod.rs
@@ -1,6 +1,7 @@
 mod context;
 mod generator;
 mod result;
+pub(crate) mod templates;
 mod utils;
 
 use crate::commands::beta::generate::generator::CodeGenerator;

--- a/src/bin/ion/commands/beta/generate/mod.rs
+++ b/src/bin/ion/commands/beta/generate/mod.rs
@@ -1,7 +1,7 @@
 mod context;
 mod generator;
 mod result;
-pub(crate) mod templates;
+mod templates;
 mod utils;
 
 use crate::commands::beta::generate::generator::CodeGenerator;

--- a/src/bin/ion/commands/beta/generate/templates/mod.rs
+++ b/src/bin/ion/commands/beta/generate/templates/mod.rs
@@ -1,0 +1,35 @@
+// This module includes constants that can be used to render templates for generating code.
+// Currently, there is no other way to add resources like `.templ` files in cargo binary crate.
+// Using these constants allows the binary to access templates through these constants.
+
+/// Represents java template constants
+pub(crate) mod java {
+    pub(crate) const CLASS: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/bin/ion/commands/beta/generate/templates/java/class.templ"
+    ));
+    pub(crate) const NESTED_TYPE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/bin/ion/commands/beta/generate/templates/java/nested_type.templ"
+    ));
+}
+
+/// Represents rust template constants
+pub(crate) mod rust {
+    pub(crate) const STRUCT: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/bin/ion/commands/beta/generate/templates/rust/struct.templ"
+    ));
+    pub(crate) const RESULT: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/bin/ion/commands/beta/generate/templates/rust/result.templ"
+    ));
+    pub(crate) const NESTED_TYPE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/bin/ion/commands/beta/generate/templates/rust/nested_type.templ"
+    ));
+    pub(crate) const IMPORT: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/bin/ion/commands/beta/generate/templates/rust/import.templ"
+    ));
+}


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
This PR works on adding template resources as constants. This change makes the template files as string constants which can be used by the binary crate.

### List of changes:
- Adds template modules `rust` and `java` that contains all string constants pointing to corresponding template.
- Changed `tera` to be instantiated as `default` and then all these constants are used to add raw templates to `tera`.

### Test
Tested with `brew test` to make sure that `generate` subcommand has access to templates.
Related PR: https://github.com/amazon-ion/homebrew-ion-cli/pull/7

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
