### PR TITLE
Adds a new model for code generator

### DIFF
--- a/src/bin/ion/commands/beta/generate/mod.rs
+++ b/src/bin/ion/commands/beta/generate/mod.rs
@@ -4,6 +4,8 @@ mod result;
 mod templates;
 mod utils;
 
+mod model;
+
 use crate::commands::beta::generate::generator::CodeGenerator;
 use crate::commands::beta::generate::utils::{JavaLanguage, RustLanguage};
 use crate::commands::IonCliCommand;

--- a/src/bin/ion/commands/beta/generate/model.rs
+++ b/src/bin/ion/commands/beta/generate/model.rs
@@ -1,6 +1,5 @@
 use ion_schema::isl::isl_type::IslType;
 use std::collections::HashMap;
-use std::ops::Deref;
 // This module contains a data model that the code generator can use to render a template based on the type of the model.
 // Currently, this same data model is represented by `AbstractDataType` but it doesn't hold all the information for the template.
 // e.g. currently there are different fields in the template that hold this information like fields, target_kind_name, abstract_data_type.
@@ -11,43 +10,41 @@ use std::ops::Deref;
 use crate::commands::beta::generate::context::SequenceType;
 use serde::Serialize;
 
+/// Represent a node in the data model tree of the generated code.
+/// Each node in this tree could either be a module/package or a concrete data structure(class, struct, enum etc.).
+/// This tree structure will be used by code generator and templates to render the generated code as per given ISL type definition hierarchy.
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
-pub struct AbstractDataType {
-    // Represents the fully qualified name for this data model
-    name: FullyQualifiedTypeName,
-    // Represents doc comment for the generated code
-    doc_comment: String,
+pub struct DataModelNode {
+    // Represents the name of this data model
+    // Note: It doesn't point to the fully qualified name. To get fully qualified name use `fully_qualified_name()` from `AbstractDataType`.
+    name: String,
     // Represents the type of the data model
     // It can be `None` for modules or packages.
-    code_gen_type: Option<AbstractDataKind>,
+    code_gen_type: Option<AbstractDataType>,
     // Represents the nested types for this data model
-    nested_types: Vec<AbstractDataType>,
-    // Represents the source ISL type which can be used to get other constraints useful for this type.
-    // For example, getting the length of this sequence from `container_length` constraint or getting a `regex` value for string type.
-    // This will also be useful for `text` type to verify if this is a `string` or `symbol`.
-    source: Option<IslType>,
+    nested_types: Vec<DataModelNode>,
 }
 
-impl AbstractDataType {
+impl DataModelNode {
     #![allow(dead_code)]
     pub fn is_scalar(&self) -> bool {
         if let Some(code_gen_type) = &self.code_gen_type {
-            return matches!(code_gen_type, AbstractDataKind::Scalar);
+            return matches!(code_gen_type, AbstractDataType::Scalar(_));
         }
         false
     }
 
     pub fn is_sequence(&self) -> bool {
         if let Some(code_gen_type) = &self.code_gen_type {
-            return matches!(code_gen_type, AbstractDataKind::Sequence(_));
+            return matches!(code_gen_type, AbstractDataType::Sequence(_));
         }
         false
     }
 
     pub fn is_structure(&self) -> bool {
         if let Some(code_gen_type) = &self.code_gen_type {
-            return matches!(code_gen_type, AbstractDataKind::Structure(_));
+            return matches!(code_gen_type, AbstractDataType::Structure(_));
         }
         false
     }
@@ -62,13 +59,13 @@ type FullyQualifiedTypeName = Vec<String>;
 /// Represents a fully qualified type name for a type reference
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct FullQualifiedTypeReference {
+pub struct FullyQualifiedTypeReference {
     // Represents fully qualified name of the type
     // e.g. In Java, `org.example.Foo`
     //      In Rust, `crate::org::example::Foo`
     type_name: FullyQualifiedTypeName,
     // For types with parameters this will represent the nested parameter
-    parameters: Option<Box<FullQualifiedTypeReference>>,
+    parameters: Vec<FullyQualifiedTypeReference>,
 }
 
 /// A target-language-agnostic data type that determines which template(s) to use for code generation.
@@ -76,26 +73,122 @@ pub struct FullQualifiedTypeReference {
 // TODO: Add more code gent types like sum/discriminated union, enum and map.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub enum AbstractDataKind {
-    // Represents a scalar value (e.g. a string or integer or user defined type)
-    // e.g. Given below ISL,
-    // ```
-    // type::{
-    //   name: scalar_type,
-    //   type: int
-    // }
-    // ```
-    // Corresponding abstract type in Rust would look like following:
-    // ```
-    // struct ScalarType {
-    //    value: i64
-    // }
-    // ```
-    Scalar,
+pub enum AbstractDataType {
+    // Represents a top level scalar type definition which also has a name attached to it.
+    WrappedScalar(WrappedScalar),
+    // Represents a nested/inline scalar value (e.g. a string or integer or user defined type)
+    Scalar(Scalar),
     // A series of zero or more values whose type is described by the nested `element_type`
     Sequence(Sequence),
     // A collection of field name/value pairs (e.g. a map)
     Structure(Structure),
+}
+
+impl AbstractDataType {
+    #![allow(dead_code)]
+    pub fn doc_comment(&self) -> Option<String> {
+        match self {
+            AbstractDataType::WrappedScalar(WrappedScalar { doc_comment, .. }) => {
+                doc_comment.to_owned()
+            }
+            AbstractDataType::Scalar(Scalar { doc_comment, .. }) => doc_comment.to_owned(),
+            AbstractDataType::Sequence(Sequence { doc_comment, .. }) => {
+                Some(doc_comment.to_string())
+            }
+            AbstractDataType::Structure(Structure { doc_comment, .. }) => {
+                Some(doc_comment.to_string())
+            }
+        }
+    }
+
+    pub fn fully_qualified_name(&self) -> FullyQualifiedTypeName {
+        match self {
+            AbstractDataType::WrappedScalar(w) => w.fully_qualified_type_name().to_owned(),
+            AbstractDataType::Scalar(s) => s.name.to_owned(),
+            AbstractDataType::Sequence(seq) => seq.name.to_owned(),
+            AbstractDataType::Structure(structure) => structure.name.to_owned(),
+        }
+    }
+}
+
+/// Represents a nested/inline scalar type (e.g. a string or integer or user defined type)
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Scalar {
+    // Represents the fully qualified name for this data model
+    // For any nested/inline scalar type this would be the name of that type.
+    // e.g.
+    // ```
+    // type::{
+    //    name: foo,
+    //    type: list,
+    //    element: string // this is a nested scalar type
+    // }
+    // ```
+    // Corresponding `FullyQualifiedName` would be `vec!["String"]` and `scalar_type` would be `None`.
+    name: FullyQualifiedTypeName,
+    // Represents doc comment for the generated code
+    // If this is a top level scalar type definition then this will have `Some(doc_comment)`,
+    // Otherwise this is `None`.
+    doc_comment: Option<String>,
+    // Represents the source ISL type which can be used to get other constraints useful for this type.
+    // For example, getting the length of this sequence from `container_length` constraint or getting a `regex` value for string type.
+    // This will also be useful for `text` type to verify if this is a `string` or `symbol`.
+    // TODO: `IslType` does not implement `Serialize`, define a custom implementation or define methods on this field that returns values which could be serialized.
+    #[serde(skip_serializing)]
+    source: IslType,
+}
+
+/// Represents a top level scalar type definition
+/// e.g. Given below ISL,
+/// ```
+/// type::{
+///   name: scalar_type,
+///   type: int
+/// }
+/// ```
+/// Corresponding generated code in Rust would look like following:
+/// ```
+/// struct ScalarType {
+///    value: i64
+/// }
+/// ```
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct WrappedScalar {
+    // Represents the fully qualified name of this top level scalar type
+    // e.g. Given below ISL,
+    // ```
+    // type::{
+    //   name: foo,
+    //   type: string
+    // }
+    // ```
+    // Corresponding `FullyQualifiedTypeReference` would be as following:
+    // ```
+    // FullyQualifiedTypeReference {
+    //    type_name: vec!["Foo"], // name of the top level scalar type
+    //    parameters: vec![FullyQualifiedTypeReference {type_name: vec!["String"] }] // nested type name for the scalar value
+    // }
+    // ```
+    name: FullyQualifiedTypeReference,
+    // Represents the scalar type
+    // Represents doc comment for the generated code
+    // If this is a top level scalar type definition then this will have `Some(doc_comment)`,
+    // Otherwise this is `None`.
+    doc_comment: Option<String>,
+    // Represents the source ISL type which can be used to get other constraints useful for this type.
+    // For example, getting the length of this sequence from `container_length` constraint or getting a `regex` value for string type.
+    // This will also be useful for `text` type to verify if this is a `string` or `symbol`.
+    // TODO: `IslType` does not implement `Serialize`, define a custom implementation or define methods on this field that returns values which could be serialized.
+    #[serde(skip_serializing)]
+    source: IslType,
+}
+
+impl WrappedScalar {
+    pub fn fully_qualified_type_name(&self) -> FullyQualifiedTypeName {
+        self.name.type_name.to_owned()
+    }
 }
 
 /// Represents series of zero or more values whose type is described by the nested `element_type`
@@ -109,7 +202,7 @@ pub enum AbstractDataKind {
 ///   element: int
 /// }
 /// ```
-/// Corresponding abstract type in Rust would look like following:
+/// Corresponding generated code in Rust would look like following:
 /// ```
 /// struct SequenceType {
 ///    value: Vec<i64>
@@ -118,11 +211,21 @@ pub enum AbstractDataKind {
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Sequence {
+    // Represents the fully qualified name for this data model
+    name: FullyQualifiedTypeName,
+    // Represents doc comment for the generated code
+    doc_comment: String,
     // Represents the fully qualified name with namespace where each element of vector stores a module name or class/struct name.
     // _Note: that a hashmap with (FullQualifiedTypeReference, DataModel) pairs will be stored in code generator to get information on the element_type name used here._
-    element_type: FullQualifiedTypeReference,
+    element_type: FullyQualifiedTypeReference,
     // Represents the type of the sequence which is either `sexp` or `list`.
     sequence_type: SequenceType,
+    // Represents the source ISL type which can be used to get other constraints useful for this type.
+    // For example, getting the length of this sequence from `container_length` constraint or getting a `regex` value for string type.
+    // This will also be useful for `text` type to verify if this is a `string` or `symbol`.
+    // TODO: `IslType` does not implement `Serialize`, define a custom implementation or define methods on this field that returns values which could be serialized.
+    #[serde(skip_serializing)]
+    source: IslType,
 }
 
 /// Represents a collection of field name/value pairs (e.g. a map)
@@ -136,7 +239,7 @@ pub struct Sequence {
 ///   }
 /// }
 /// ```
-/// Corresponding abstract type in Rust would look like following:
+/// Corresponding generated code in Rust would look like following:
 /// ```
 /// struct StructType {
 ///    a: i64,
@@ -146,10 +249,20 @@ pub struct Sequence {
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Structure {
+    // Represents the fully qualified name for this data model
+    name: FullyQualifiedTypeName,
+    // Represents doc comment for the generated code
+    doc_comment: String,
     // Represents whether the struct has closed fields or not
     is_closed: bool,
     // Represents the fields of the struct i.e. (field_name, field_value) pairs
     // field_value represents the type of the value field as fully qualified name
     // _Note: that a hashmap with (FullQualifiedTypeReference, DataModel) pairs will be stored in code generator to get information on the field_value name used here._
-    fields: HashMap<String, FullQualifiedTypeReference>,
+    fields: HashMap<String, FullyQualifiedTypeReference>,
+    // Represents the source ISL type which can be used to get other constraints useful for this type.
+    // For example, getting the length of this sequence from `container_length` constraint or getting a `regex` value for string type.
+    // This will also be useful for `text` type to verify if this is a `string` or `symbol`.
+    // TODO: `IslType` does not implement `Serialize`, define a custom implementation or define methods on this field that returns values which could be serialized.
+    #[serde(skip_serializing)]
+    source: IslType,
 }

--- a/src/bin/ion/commands/beta/generate/model.rs
+++ b/src/bin/ion/commands/beta/generate/model.rs
@@ -88,7 +88,9 @@ impl AbstractDataType {
     #![allow(dead_code)]
     pub fn doc_comment(&self) -> Option<&str> {
         match self {
-            AbstractDataType::WrappedScalar(WrappedScalar { doc_comment, .. }) => Some(doc_comment),
+            AbstractDataType::WrappedScalar(WrappedScalar { doc_comment, .. }) => {
+                doc_comment.as_ref().map(|s| s.as_str())
+            }
             AbstractDataType::Scalar(Scalar { doc_comment, .. }) => {
                 doc_comment.as_ref().map(|s| s.as_str())
             }
@@ -168,7 +170,8 @@ pub struct WrappedScalar {
     // ```
     name: FullyQualifiedTypeReference,
     // Represents doc comment for the generated code
-    doc_comment: String,
+    // If the doc comment is provided for this scalar type then this is `Some(doc_comment)`, other it is None.
+    doc_comment: Option<String>,
     // Represents the source ISL type which can be used to get other constraints useful for this type.
     // For example, getting the length of this sequence from `container_length` constraint or getting a `regex` value for string type.
     // This will also be useful for `text` type to verify if this is a `string` or `symbol`.

--- a/src/bin/ion/commands/beta/generate/model.rs
+++ b/src/bin/ion/commands/beta/generate/model.rs
@@ -1,0 +1,154 @@
+use ion_schema::isl::isl_type::IslType;
+use std::collections::HashMap;
+use std::ops::Deref;
+// This module contains a data model that code generator cna use to render a template based on the type of the model.
+// Currently, this same data model represented is by `AbstractDataType` but it doesn't hold all the information for the template.
+// e.g. currently there are different fields in template that hold this information like fields, target_kind_name, abstract_data_type.
+// Also, current approach doesn't allow having nested sequences in the generated code. Because the `element_type` in `AbstractDataType::Sequence`
+// doesn't have information on its nested types' `element_type`. This can be resolved with below defined new data model.
+// _Note: This model will eventually use a map (FullQualifiedTypeReference, DataModel) to resolve some the references in container types(sequence or structure)._
+// TODO: This is not yet used in the implementation, modify current implementation to use this data model.
+use crate::commands::beta::generate::context::SequenceType;
+use serde::Serialize;
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq)]
+pub struct DataModel {
+    // Represents the fully qualified name for this data model
+    name: FullyQualifiedTypeName,
+    // Represents doc comment for the generated code
+    doc_comment: String,
+    // Represents the type of the data model
+    // It can be `None` for modules or packages.
+    code_gen_type: Option<Box<CodeGenType>>,
+    // Represents the nested types for this data model
+    nested_types: Vec<DataModel>,
+    // Represents the source ISL type which can be used to get other constraints useful for this type.
+    // For example, getting the length of this sequence from `container_length` constraint or getting a `regex` value for string type.
+    // This will also be useful for `text` type to verify if this is a `string` or `symbol`.
+    source: Option<IslType>,
+}
+
+impl DataModel {
+    pub fn is_scalar(&self) -> bool {
+        if let Some(code_gen_type) = &self.code_gen_type {
+            return matches!(code_gen_type.deref(), CodeGenType::Scalar);
+        }
+        false
+    }
+
+    pub fn is_sequence(&self) -> bool {
+        if let Some(code_gen_type) = &self.code_gen_type {
+            return matches!(code_gen_type.deref(), CodeGenType::Sequence(_));
+        }
+        false
+    }
+
+    pub fn is_structure(&self) -> bool {
+        if let Some(code_gen_type) = &self.code_gen_type {
+            return matches!(code_gen_type.deref(), CodeGenType::Structure(_));
+        }
+        false
+    }
+}
+
+/// Represents a fully qualified type name for a type definition
+/// e.g. For a `Foo` class in `org.example` namespace
+///     In Java, `org.example.Foo`
+///     In Rust, `org::example::Foo`
+type FullyQualifiedTypeName = Vec<String>;
+
+/// Represents a fully qualified type name for a type reference
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct FullQualifiedTypeReference {
+    // Represents fully qualified name of the type
+    // e.g. In Java, `org.example.Foo`
+    //      In Rust, `crate::org::example::Foo`
+    type_name: FullyQualifiedTypeName,
+    // For types with parameters this will represent the nested parameter
+    parameters: Box<FullQualifiedTypeReference>,
+}
+
+/// A target-language-agnostic data type that determines which template(s) to use for code generation.
+#[allow(dead_code)]
+// TODO: Add more code gent types like sum/discriminated union, enum and map.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub enum CodeGenType {
+    // Represents a scalar value (e.g. a string or integer or user defined type)
+    // e.g. Given below ISL,
+    // ```
+    // type::{
+    //   name: scalar_type,
+    //   type: int
+    // }
+    // ```
+    // Corresponding abstract type in Rust would look like following:
+    // ```
+    // struct ScalarType {
+    //    value: i64
+    // }
+    // ```
+    Scalar,
+    // A series of zero or more values whose type is described by the nested `element_type`
+    Sequence(Sequence),
+    // A collection of field name/value pairs (e.g. a map)
+    Structure(Structure),
+}
+
+/// Represents series of zero or more values whose type is described by the nested `element_type`
+/// and sequence type is described by nested `sequence_type` (e.g. List or SExp).
+/// If there is no `element` constraint present in schema type then `element_type` will be None.
+/// If there is no `type` constraint present in schema type then `sequence_type` will be None.
+/// e.g. Given below ISL,
+/// ```
+/// type::{
+///   name: sequence_type,
+///   element: int
+/// }
+/// ```
+/// Corresponding abstract type in Rust would look like following:
+/// ```
+/// struct SequenceType {
+///    value: Vec<i64>
+/// }
+/// ```
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Sequence {
+    // Represents the fully qualified name with namespace where each element of vector stores a module name or class/struct name.
+    // _Note: that a hashmap with (FullQualifiedTypeReference, DataModel) pairs will be stored in code generator to get information on the element_type name used here._
+    element_type: FullQualifiedTypeReference,
+    // Represents the type of the sequence which is either `sexp` or `list`.
+    sequence_type: SequenceType,
+}
+
+/// Represents a collection of field name/value pairs (e.g. a map)
+/// e.g. Given below ISL,
+/// ```
+/// type::{
+///   name: struct_type,
+///   fields: {
+///      a: int,
+///      b: string,
+///   }
+/// }
+/// ```
+/// Corresponding abstract type in Rust would look like following:
+/// ```
+/// struct StructType {
+///    a: i64,
+///    b: String,
+/// }
+/// ```
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Structure {
+    // Represents whether the struct has closed fields or not
+    is_closed: bool,
+    // Represents the fields of the struct i.e. (field_name, field_value) pairs
+    // field_value represents the type of the value field as fully qualified name
+    // _Note: that a hashmap with (FullQualifiedTypeReference, DataModel) pairs will be stored in code generator to get information on the field_value name used here._
+    fields: HashMap<String, FullQualifiedTypeReference>,
+}

--- a/src/bin/ion/commands/beta/generate/utils.rs
+++ b/src/bin/ion/commands/beta/generate/utils.rs
@@ -66,12 +66,6 @@ pub trait Language {
     ///     target_type = "Foo" returns "Vec<Foo>"
     fn target_type_as_sequence(target_type: &Option<String>) -> Option<String>;
 
-    /// Returns the [Case] based on programming languages
-    /// e.g.  
-    ///     Rust field name case -> [Case::Snake]
-    ///     Java field name case -> [Case::Camel]
-    fn field_name_case() -> Case;
-
     /// Returns true if the type name specified is provided by the target language implementation
     fn is_built_in_type(name: &str) -> bool;
 
@@ -120,10 +114,6 @@ impl Language for JavaLanguage {
                 None => format!("ArrayList<{}>", target_type_name),
             }
         })
-    }
-
-    fn field_name_case() -> Case {
-        Case::Camel
     }
 
     fn is_built_in_type(name: &str) -> bool {
@@ -195,10 +185,6 @@ impl Language for RustLanguage {
         target_type
             .as_ref()
             .map(|target_type_name| format!("Vec<{}>", target_type_name))
-    }
-
-    fn field_name_case() -> Case {
-        Case::Snake
     }
 
     fn is_built_in_type(name: &str) -> bool {


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
This PR is adds a new model for code generator to make it simpler for getting information on nested types and element type in sequence.

### List of changes:
- `DataModel` is a the new abstract data type that will be used by code generator to render templates.
- `CodeGenType` is similar to the prior `AbstractDataType` but more informative includes fields details and element type details.
- `FullyQualifiedTypeName` and `FullyQualifiedTypeReference` are used for storing all levels of the fully qualified name of the type.
- This PR only introduces the model but doesn't yet use it in the implementation.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
