### PR TITLE
Use MultiGzDecoder to support multi-member gzip files

### DIFF
--- a/src/bin/ion/auto_decompress.rs
+++ b/src/bin/ion/auto_decompress.rs
@@ -29,7 +29,7 @@ where
     match detected_type.as_ref().map(Type::extension) {
         Some("gz") => {
             // "rewind" to let the decompressor read magic bytes again
-            let zreader = Box::new(flate2::read::GzDecoder::new(stream));
+            let zreader = Box::new(flate2::read::MultiGzDecoder::new(stream));
             Ok((CompressionDetected::Gzip, BufReader::new(zreader)))
         }
         Some("zst") => {


### PR DESCRIPTION
### Issue #, if available: #126

### Description of changes:
This PR changes the GzDecoder used for decompressing gzip'd inputs to a MultiGzDecoder in order to handle multi-member gzip files.

Pre-PR (using homebrew'd ion-cli):
```
glitch@147dda5e5395 ~/C/ion-cli> ion dump user-data.ion.gz | ion beta count
1213
```
Post-PR:
```
glitch@147dda5e5395 ~/C/ion-cli> cargo run --release dump user-data.ion.gz | ion beta count
    Finished release [optimized] target(s) in 0.19s
     Running `target/release/ion dump user-data.ion.gz`
2541
glitch@147dda5e5395 ~/C/ion-cli> 

```
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
