### PR TITLE
Refactor namespace logic out of default command logic

### DIFF
--- a/src/bin/ion/commands/cat.rs
+++ b/src/bin/ion/commands/cat.rs
@@ -16,6 +16,14 @@ impl IonCliCommand for CatCommand {
         "Prints all Ion input files to the specified output in the requested format."
     }
 
+    fn is_stable(&self) -> bool {
+        true
+    }
+
+    fn is_porcelain(&self) -> bool {
+        false
+    }
+
     fn configure_args(&self, command: Command) -> Command {
         command
             .alias("dump")

--- a/src/bin/ion/commands/command_namespace.rs
+++ b/src/bin/ion/commands/command_namespace.rs
@@ -1,0 +1,84 @@
+use crate::commands::{IonCliCommand, WithIonCliArgument, UNSTABLE_FLAG};
+use clap::{ArgMatches, Command as ClapCommand};
+use std::process;
+
+/// A trait that handles the implementation of [IonCliCommand] for command namespaces.
+pub trait IonCliNamespace {
+    fn name(&self) -> &'static str;
+    fn about(&self) -> &'static str;
+    fn subcommands(&self) -> Vec<Box<dyn IonCliCommand>>;
+}
+
+impl<T: IonCliNamespace> IonCliCommand for T {
+    // Namespaces can't be used on their own, so we'll pretend that they are all stable and
+    // let the leaf commands handle stability.
+    fn is_stable(&self) -> bool {
+        true
+    }
+
+    // Namespaces can't be used on their own, so we'll pretend that they are all plumbing and
+    // let the leaf commands handle plumbing vs porcelain.
+    fn is_porcelain(&self) -> bool {
+        false
+    }
+
+    fn name(&self) -> &'static str {
+        IonCliNamespace::name(self)
+    }
+
+    fn about(&self) -> &'static str {
+        IonCliNamespace::about(self)
+    }
+
+    fn configure_args(&self, command: ClapCommand) -> ClapCommand {
+        // Create a `ClapCommand` representing each of this command's subcommands.
+        let clap_subcommands: Vec<_> = self
+            .subcommands()
+            .iter()
+            .map(|s| s.clap_command())
+            .collect();
+
+        let mut command = command
+            .subcommand_required(true)
+            .subcommands(clap_subcommands);
+
+        // If there are subcommands, add them to the configuration and set 'subcommand_required'.
+        let has_unstable_subcommand = self.subcommands().iter().any(|sc| !sc.is_stable());
+        if has_unstable_subcommand {
+            command = command.show_unstable_flag();
+        }
+        command
+    }
+
+    fn run(&self, command_path: &mut Vec<String>, args: &ArgMatches) -> anyhow::Result<()> {
+        // Safe to unwrap because if this is a namespace are subcommands, then clap has already
+        // ensured that a known subcommand is present in args.
+        let (subcommand_name, subcommand_args) = args.subcommand().unwrap();
+        let subcommands = self.subcommands();
+        let subcommand: &dyn IonCliCommand = subcommands
+            .iter()
+            .find(|sc| sc.name() == subcommand_name)
+            .unwrap()
+            .as_ref();
+
+        match (subcommand.is_stable(), args.get_flag(UNSTABLE_FLAG)) {
+            // Warn if using an unnecessary `-X`
+            (true, true) => eprintln!(
+                "'{}' is stable and does not require opt-in",
+                subcommand_name
+            ),
+            // Error if missing a required `-X`
+            (false, false) => {
+                eprintln!(
+                    "'{}' is unstable and requires explicit opt-in",
+                    subcommand_name
+                );
+                process::exit(1)
+            }
+            _ => {}
+        }
+
+        command_path.push(subcommand_name.to_owned());
+        subcommand.run(command_path, subcommand_args)
+    }
+}

--- a/src/bin/ion/commands/count.rs
+++ b/src/bin/ion/commands/count.rs
@@ -19,6 +19,10 @@ impl IonCliCommand for CountCommand {
         false
     }
 
+    fn is_porcelain(&self) -> bool {
+        false
+    }
+
     fn configure_args(&self, command: Command) -> Command {
         command.with_input()
     }

--- a/src/bin/ion/commands/from/json.rs
+++ b/src/bin/ion/commands/from/json.rs
@@ -16,11 +16,20 @@ impl IonCliCommand for FromJsonCommand {
     }
 
     fn is_stable(&self) -> bool {
+        false // TODO: Should this be true?
+    }
+
+    fn is_porcelain(&self) -> bool {
         false
     }
 
     fn configure_args(&self, command: Command) -> Command {
-        command.with_input().with_output().with_format()
+        // Args must be identical to CatCommand so that we can safely delegate
+        command
+            .with_input()
+            .with_output()
+            .with_format()
+            .with_ion_version()
     }
 
     fn run(&self, command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {

--- a/src/bin/ion/commands/from/mod.rs
+++ b/src/bin/ion/commands/from/mod.rs
@@ -1,3 +1,4 @@
+use crate::commands::command_namespace::IonCliNamespace;
 use crate::commands::IonCliCommand;
 
 use crate::commands::from::json::FromJsonCommand;
@@ -6,7 +7,7 @@ pub mod json;
 
 pub struct FromNamespace;
 
-impl IonCliCommand for FromNamespace {
+impl IonCliNamespace for FromNamespace {
     fn name(&self) -> &'static str {
         "from"
     }

--- a/src/bin/ion/commands/generate/mod.rs
+++ b/src/bin/ion/commands/generate/mod.rs
@@ -30,6 +30,10 @@ impl IonCliCommand for GenerateCommand {
         false
     }
 
+    fn is_porcelain(&self) -> bool {
+        false
+    }
+
     fn configure_args(&self, command: Command) -> Command {
         command
             .arg(

--- a/src/bin/ion/commands/head.rs
+++ b/src/bin/ion/commands/head.rs
@@ -16,6 +16,14 @@ impl IonCliCommand for HeadCommand {
         "Prints the specified number of top-level values in the input stream."
     }
 
+    fn is_stable(&self) -> bool {
+        true
+    }
+
+    fn is_porcelain(&self) -> bool {
+        false
+    }
+
     fn configure_args(&self, command: Command) -> Command {
         // Same flags as `cat`, but with an added `--values` flag to specify the number of values to
         // write.

--- a/src/bin/ion/commands/inspect.rs
+++ b/src/bin/ion/commands/inspect.rs
@@ -29,6 +29,10 @@ between versions. Stable output for programmatic use cases is a
 non-goal."
     }
 
+    fn is_stable(&self) -> bool {
+        true
+    }
+
     fn is_porcelain(&self) -> bool {
         true
     }

--- a/src/bin/ion/commands/schema/mod.rs
+++ b/src/bin/ion/commands/schema/mod.rs
@@ -1,6 +1,7 @@
 pub mod load;
 pub mod validate;
 
+use crate::commands::command_namespace::IonCliNamespace;
 use crate::commands::IonCliCommand;
 
 use crate::commands::schema::load::LoadCommand;
@@ -8,7 +9,7 @@ use crate::commands::schema::validate::ValidateCommand;
 
 pub struct SchemaNamespace;
 
-impl IonCliCommand for SchemaNamespace {
+impl IonCliNamespace for SchemaNamespace {
     fn name(&self) -> &'static str {
         "schema"
     }

--- a/src/bin/ion/commands/schema/validate.rs
+++ b/src/bin/ion/commands/schema/validate.rs
@@ -28,6 +28,10 @@ impl IonCliCommand for ValidateCommand {
         false
     }
 
+    fn is_porcelain(&self) -> bool {
+        true // TODO: Should this command be made into plumbing?
+    }
+
     fn configure_args(&self, command: Command) -> Command {
         command
             .arg(

--- a/src/bin/ion/commands/symtab/filter.rs
+++ b/src/bin/ion/commands/symtab/filter.rs
@@ -22,6 +22,10 @@ impl IonCliCommand for SymtabFilterCommand {
         false
     }
 
+    fn is_porcelain(&self) -> bool {
+        false
+    }
+
     fn configure_args(&self, command: Command) -> Command {
         command.with_input()
             .with_output()

--- a/src/bin/ion/commands/symtab/mod.rs
+++ b/src/bin/ion/commands/symtab/mod.rs
@@ -1,3 +1,4 @@
+use crate::commands::command_namespace::IonCliNamespace;
 use crate::commands::symtab::filter::SymtabFilterCommand;
 use crate::commands::IonCliCommand;
 
@@ -5,7 +6,7 @@ pub mod filter;
 
 pub struct SymtabNamespace;
 
-impl IonCliCommand for SymtabNamespace {
+impl IonCliNamespace for SymtabNamespace {
     fn name(&self) -> &'static str {
         "symtab"
     }

--- a/src/bin/ion/commands/to/json.rs
+++ b/src/bin/ion/commands/to/json.rs
@@ -25,6 +25,10 @@ impl IonCliCommand for ToJsonCommand {
         false
     }
 
+    fn is_porcelain(&self) -> bool {
+        false
+    }
+
     fn configure_args(&self, command: Command) -> Command {
         // NOTE: it may be necessary to add format-specific options. For example, a "pretty" option
         // would make sense for JSON, but not binary formats like CBOR.

--- a/src/bin/ion/commands/to/mod.rs
+++ b/src/bin/ion/commands/to/mod.rs
@@ -1,3 +1,4 @@
+use crate::commands::command_namespace::IonCliNamespace;
 use crate::commands::IonCliCommand;
 
 use crate::commands::to::json::ToJsonCommand;
@@ -6,7 +7,7 @@ pub mod json;
 
 pub struct ToNamespace;
 
-impl IonCliCommand for ToNamespace {
+impl IonCliNamespace for ToNamespace {
     fn name(&self) -> &'static str {
         "to"
     }

--- a/src/bin/ion/main.rs
+++ b/src/bin/ion/main.rs
@@ -6,7 +6,7 @@ mod output;
 mod transcribe;
 
 use anyhow::Result;
-use commands::IonCliCommand;
+use commands::{IonCliCommand, IonCliNamespace};
 use ion_rs::IonError;
 use std::io::ErrorKind;
 
@@ -25,7 +25,7 @@ use crate::commands::to::ToNamespace;
 fn main() -> Result<()> {
     let root_command = RootCommand;
     let args = root_command.clap_command().get_matches();
-    let mut command_path: Vec<String> = vec![root_command.name().to_owned()];
+    let mut command_path: Vec<String> = vec![IonCliNamespace::name(&root_command).to_owned()];
 
     if let Err(e) = root_command.run(&mut command_path, &args) {
         match e.downcast_ref::<IonError>() {
@@ -43,7 +43,7 @@ fn main() -> Result<()> {
 
 pub struct RootCommand;
 
-impl IonCliCommand for RootCommand {
+impl IonCliNamespace for RootCommand {
     fn name(&self) -> &'static str {
         "ion"
     }


### PR DESCRIPTION
### Issue #, if available:

Follow up for #128.

### Description of changes:

* Changes the defaults of `IonCliCommand`'s `is_stable()` to `false` and `is_porcelain()` to `true`.
* Creates a new trait for namespaces so that they are stable and plumbing by default. Also has the benefit of extracting the namespace logic out of `IonCliCommand`.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
