### PR TITLE
Adds hash subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,12 +156,28 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bstr"
@@ -469,11 +485,20 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "crypto-common",
 ]
 
@@ -846,6 +871,7 @@ dependencies = [
  "clap",
  "colored",
  "convert_case",
+ "digest 0.9.0",
  "flate2",
  "infer",
  "ion-rs 1.0.0-rc.6",
@@ -855,6 +881,8 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "sha2 0.9.9",
+ "sha3",
  "tempfile",
  "tera",
  "termcolor",
@@ -893,12 +921,14 @@ dependencies = [
  "bumpalo",
  "chrono",
  "delegate 0.12.0",
+ "digest 0.9.0",
  "ice_code",
  "nom",
  "num-integer",
  "num-traits",
  "serde",
  "serde_with",
+ "sha2 0.9.9",
  "smallvec",
  "thiserror",
 ]
@@ -963,6 +993,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -1084,6 +1123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "pager"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,7 +1195,7 @@ checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
 dependencies = [
  "once_cell",
  "pest",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1474,13 +1519,38 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
+ "opaque-debug",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,12 @@ keywords = ["format", "parse", "encode"]
 anyhow = "1.0"
 clap = { version = "4.5.8", features = ["cargo", "env"] }
 colored = "2.0.0"
+digest = "0.9"
+sha2 = "0.9"
+sha3 = "0.9"
 flate2 = "1.0"
 infer = "0.15.0"
-ion-rs = { version = "1.0.0-rc.6", features = ["experimental"] }
+ion-rs = { version = "1.0.0-rc.6", features = ["experimental", "experimental-ion-hash"] }
 tempfile = "3.2.0"
 ion-schema = "0.10.0"
 serde = { version = "1.0.163", features = ["derive"] }

--- a/src/bin/ion/commands/hash.rs
+++ b/src/bin/ion/commands/hash.rs
@@ -1,0 +1,113 @@
+use crate::commands::{CommandIo, IonCliCommand, WithIonCliArgument};
+use anyhow::Result;
+use clap::builder::PossibleValue;
+use clap::{value_parser, Arg, ArgAction, ArgMatches, Command, ValueEnum};
+use ion_rs::ion_hash::IonHasher;
+use ion_rs::*;
+use sha2::{Sha256, Sha512};
+use sha3::{Sha3_256, Sha3_512};
+use std::io::Write;
+
+// Macro to eliminate repetitive code for each hash algorithm.
+macro_rules! supported_hash_functions {
+    ($($name:literal => $hash:ident),+$(,)?) => {
+        #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
+        enum DigestType {
+            #[default]
+            $($hash),+
+        }
+        impl DigestType {
+            const VARIANTS: &'static [DigestType] = &[
+                $(DigestType::$hash),+
+            ];
+
+            fn hash_it(&self, element: &Element) -> IonResult<Vec<u8>> {
+                match &self {
+                    $(DigestType::$hash => Ok($hash::hash_element(&element)?.to_vec()),)+
+                }
+            }
+        }
+        impl ValueEnum for DigestType {
+            fn value_variants<'a>() -> &'a [Self] {
+                DigestType::VARIANTS
+            }
+
+            fn to_possible_value(&self) -> Option<PossibleValue> {
+                match self {
+                    $(DigestType::$hash => Some($name.into()),)+
+                }
+            }
+        }
+    };
+}
+
+supported_hash_functions! {
+    "sha-256" => Sha256,
+    "sha-512" => Sha512,
+    "sha3-256" => Sha3_256,
+    "sha3-512" => Sha3_512,
+}
+
+pub struct HashCommand;
+
+impl IonCliCommand for HashCommand {
+    fn name(&self) -> &'static str {
+        "hash"
+    }
+
+    fn about(&self) -> &'static str {
+        "Calculates a hash of Ion values using the Ion Hash algorithm."
+    }
+
+    fn is_stable(&self) -> bool {
+        false
+    }
+
+    fn is_porcelain(&self) -> bool {
+        false
+    }
+
+    fn configure_args(&self, command: Command) -> Command {
+        command
+            .arg(
+                Arg::new("hash")
+                    .required(true)
+                    .value_parser(value_parser!(DigestType)),
+            )
+            .with_output()
+            .with_input()
+            // TODO: If we want to support other output formats, add flags for them
+            //       and an ArgGroup to ensure only one is selected.
+            //       Default right now is to emit base16 strings of the digest.
+            .arg(
+                Arg::new("raw")
+                    .long("raw")
+                    .help("Emit the digest(s) as raw bytes.")
+                    .action(ArgAction::SetTrue),
+            )
+    }
+
+    fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
+        CommandIo::new(args).for_each_input(|output, input| {
+            let mut reader = Reader::new(AnyEncoding, input.into_source())?;
+
+            for elem in reader.elements() {
+                let elem = elem?;
+                if let Some(hash) = args.get_one::<DigestType>("hash") {
+                    let digest = hash.hash_it(&elem)?;
+                    if args.get_flag("raw") {
+                        output.write_all(&digest)?;
+                    } else {
+                        let digest_string: String =
+                            digest.iter().map(|b| format!("{:02x?}", b)).collect();
+                        output.write_all(digest_string.as_bytes())?;
+                    };
+                    output.write_all("\n".as_bytes())?;
+                } else {
+                    unreachable!("clap ensures that there is a valid argument")
+                }
+            }
+            Ok(())
+        })
+    }
+}

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod count;
 pub mod from;
 #[cfg(feature = "experimental-code-gen")]
 pub mod generate;
+pub mod hash;
 pub mod head;
 pub mod inspect;
 pub mod primitive;
@@ -131,7 +132,6 @@ impl WithIonCliArgument for ClapCommand {
     fn with_input(self) -> Self {
         self.arg(
             Arg::new("input")
-                .index(1)
                 .trailing_var_arg(true)
                 .action(ArgAction::Append)
                 .help("Input file"),

--- a/src/bin/ion/main.rs
+++ b/src/bin/ion/main.rs
@@ -15,6 +15,7 @@ use crate::commands::count::CountCommand;
 use crate::commands::from::FromNamespace;
 #[cfg(feature = "experimental-code-gen")]
 use crate::commands::generate::GenerateCommand;
+use crate::commands::hash::HashCommand;
 use crate::commands::head::HeadCommand;
 use crate::commands::inspect::InspectCommand;
 use crate::commands::primitive::PrimitiveCommand;
@@ -59,6 +60,7 @@ impl IonCliNamespace for RootCommand {
             Box::new(FromNamespace),
             #[cfg(feature = "experimental-code-gen")]
             Box::new(GenerateCommand),
+            Box::new(HashCommand),
             Box::new(HeadCommand),
             Box::new(InspectCommand),
             Box::new(PrimitiveCommand),


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

Adds (experimental) `hash` subcommand.

This supports `sha-256`, `sha-512`, `sha3-256`, and `sha3-512`. We could easily add support for more hash algorithms from [here](https://github.com/RustCrypto/hashes/tree/master).

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
