### PR TITLE
Removes cargo feature flag for code-gen

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     # We want to run on external PRs, but not on internal ones as push automatically builds
     # H/T: https://github.com/Dart-Code/Dart-Code/commit/612732d5879730608baa9622bf7f5e5b7b51ae65
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amzn/ion-cli'
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-cli'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
@@ -30,12 +30,6 @@ jobs:
           command: build
           args: --verbose --workspace
       - name: Cargo Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --workspace
-      - name: Cargo Test - Code generation tests
-        if: matrix.os == 'ubuntu-latest'
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --workspace --features experimental-code-gen
+          args: --verbose --workspace
       - name: Rustfmt Check
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ ion-schema = "0.10.0"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = { version = "1.0.81", features = ["arbitrary_precision", "preserve_order"] }
 base64 = "0.21.1"
-tera = { version = "1.18.1", optional = true }
-convert_case = { version = "0.6.0", optional = true }
+tera = { version = "1.18.1" }
+convert_case = { version = "0.6.0" }
 matches = "0.1.10"
 thiserror = "1.0.50"
 zstd = "0.13.0"
@@ -43,7 +43,6 @@ tempfile = "~3.5.0"
 
 [features]
 default = []
-experimental-code-gen = ["dep:tera", "dep:convert_case"]
 
 [[bin]]
 name = "ion"

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -13,7 +13,6 @@ pub mod cat;
 mod command_namespace;
 pub mod count;
 pub mod from;
-#[cfg(feature = "experimental-code-gen")]
 pub mod generate;
 pub mod hash;
 pub mod head;

--- a/src/bin/ion/main.rs
+++ b/src/bin/ion/main.rs
@@ -13,7 +13,6 @@ use std::io::ErrorKind;
 use crate::commands::cat::CatCommand;
 use crate::commands::count::CountCommand;
 use crate::commands::from::FromNamespace;
-#[cfg(feature = "experimental-code-gen")]
 use crate::commands::generate::GenerateCommand;
 use crate::commands::hash::HashCommand;
 use crate::commands::head::HeadCommand;
@@ -58,7 +57,6 @@ impl IonCliNamespace for RootCommand {
             Box::new(CatCommand),
             Box::new(CountCommand),
             Box::new(FromNamespace),
-            #[cfg(feature = "experimental-code-gen")]
             Box::new(GenerateCommand),
             Box::new(HashCommand),
             Box::new(HeadCommand),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -218,7 +218,6 @@ fn test_write_all_values(#[case] number: i32, #[case] expected_output: &str) -> 
     Ok(())
 }
 
-#[cfg(feature = "experimental-code-gen")]
 mod code_gen_tests {
     use super::*;
     use std::fs;

--- a/tests/code-gen-tests.rs
+++ b/tests/code-gen-tests.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "experimental-code-gen")]
-
 use anyhow::Result;
 use assert_cmd::Command;
 use rstest::rstest;
@@ -91,7 +89,6 @@ fn roundtrip_tests_for_generated_code_cargo() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "experimental-code-gen")]
 #[rstest]
 #[case::any_element_list(
 r#"

--- a/tests/code-gen-tests.rs
+++ b/tests/code-gen-tests.rs
@@ -1,9 +1,16 @@
 use anyhow::Result;
 use assert_cmd::Command;
 use rstest::rstest;
+use std::fmt::format;
 use std::fs::File;
 use std::io::Write;
+use std::path::PathBuf;
 use tempfile::TempDir;
+
+/// Returns a new [PathBuf] instance with the absolute path of the "code-gen-projects" directory.
+fn code_gen_projects_path() -> PathBuf {
+    PathBuf::from_iter([env!("CARGO_MANIFEST_DIR"), "code-gen-projects"])
+}
 
 #[test]
 fn roundtrip_tests_for_generated_code_gradle() -> Result<()> {
@@ -14,22 +21,26 @@ fn roundtrip_tests_for_generated_code_gradle() -> Result<()> {
 
     // absolute paths for gradle project and executables
     let ion_executable = env!("CARGO_BIN_EXE_ion");
-    let ion_input = format!("{}/code-gen-projects/input", env!("CARGO_MANIFEST_DIR"));
-    let test_crate_path = format!(
-        "{}/code-gen-projects/java/code-gen-demo",
-        env!("CARGO_MANIFEST_DIR")
-    );
-    let gradle_executable = format!("{}/gradlew", test_crate_path);
+    let ion_input = code_gen_projects_path().join("input");
+    let test_project_path = code_gen_projects_path().join("java").join("code-gen-demo");
+
+    let gradle_executable_name = if cfg!(windows) {
+        "gradlew.bat"
+    } else {
+        "gradlew"
+    };
+
+    let gradle_executable = test_project_path.join(gradle_executable_name);
 
     // Clean and Test
     let gradle_output = std::process::Command::new(gradle_executable)
-        .current_dir(&test_crate_path)
+        .current_dir(test_project_path)
         .env("ION_CLI", ion_executable)
         .env("ION_INPUT", ion_input)
         .arg("clean")
         .arg("test")
         .output()
-        .expect("failed to execute './gradlew clean test'");
+        .expect("failed to execute Gradle targets 'clean' and 'test'");
 
     println!("status: {}", gradle_output.status);
     std::io::stdout().write_all(&gradle_output.stdout).unwrap();
@@ -48,15 +59,12 @@ fn roundtrip_tests_for_generated_code_cargo() -> Result<()> {
 
     // absolute paths for crate and executables
     let ion_executable = env!("CARGO_BIN_EXE_ion");
-    let test_crate_path = format!(
-        "{}/code-gen-projects/rust/code-gen-demo",
-        env!("CARGO_MANIFEST_DIR")
-    );
+    let test_project_path = code_gen_projects_path().join("rust").join("code-gen-demo");
     let cargo_executable = env!("CARGO");
 
     // Clean
     let cargo_clean_output = std::process::Command::new(cargo_executable)
-        .current_dir(&test_crate_path)
+        .current_dir(&test_project_path)
         .arg("clean")
         .output()
         .expect("failed to execute 'cargo clean'");
@@ -71,7 +79,7 @@ fn roundtrip_tests_for_generated_code_cargo() -> Result<()> {
 
     // Test
     let cargo_test_output = std::process::Command::new(cargo_executable)
-        .current_dir(&test_crate_path)
+        .current_dir(&test_project_path)
         .arg("test")
         .env("ION_CLI", ion_executable)
         .output()


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

It is redundant to have the `-X` flag for unstable commands and a cargo feature flag for an unstable command. This removes the cargo feature flag.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
