### PR TITLE
Adds support for Ion 1.1 to `inspect`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: CI Build
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   build:
@@ -11,7 +11,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amazon-ion/ion-cli'
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
       - name: Git Checkout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,7 +874,7 @@ dependencies = [
  "digest 0.9.0",
  "flate2",
  "infer",
- "ion-rs 1.0.0-rc.6",
+ "ion-rs 1.0.0-rc.7",
  "ion-schema",
  "matches",
  "pager",
@@ -912,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "ion-rs"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48498fecc335cec03c72629fb886386c52f13f70195990f9f0f373411a5ac3e3"
+checksum = "8b69c0fd4ca610f80c028f4cdf205b58e640e46e13f265e55db85002829636cc"
 dependencies = [
  "arrayvec",
  "base64 0.12.3",
@@ -926,6 +926,7 @@ dependencies = [
  "nom",
  "num-integer",
  "num-traits",
+ "rustc-hash",
  "serde",
  "serde_with",
  "smallvec",
@@ -1409,6 +1410,12 @@ dependencies = [
  "syn 1.0.109",
  "unicode-ident",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ sha2 = "0.9"
 sha3 = "0.9"
 flate2 = "1.0"
 infer = "0.15.0"
-ion-rs = { version = "1.0.0-rc.6", features = ["experimental", "experimental-ion-hash"] }
+ion-rs = { version = "1.0.0-rc.7", features = ["experimental", "experimental-ion-hash"] }
 tempfile = "3.2.0"
 ion-schema = "0.10.0"
 serde = { version = "1.0.163", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.80-slim-buster as builder
+FROM rust:1.80.1-bullseye as builder
 WORKDIR /usr/src/ion-cli
 COPY . .
 RUN cargo install --verbose --path .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.75-slim-buster as builder
+FROM rust:1.80-slim-buster as builder
 WORKDIR /usr/src/ion-cli
 COPY . .
 RUN cargo install --verbose --path .

--- a/src/bin/ion/commands/inspect.rs
+++ b/src/bin/ion/commands/inspect.rs
@@ -193,10 +193,10 @@ const BYTES_PER_ROW: usize = 8;
 /// otherwise.
 trait CommentFn<'x>: FnMut(&mut CommandOutput, LazyValue<'x, AnyEncoding>) -> Result<bool> {}
 
-impl<'x, F> CommentFn<'x> for F
-where
-    F: FnMut(&mut CommandOutput, LazyValue<'x, AnyEncoding>) -> Result<bool>,
-{}
+impl<'x, F> CommentFn<'x> for F where
+    F: FnMut(&mut CommandOutput, LazyValue<'x, AnyEncoding>) -> Result<bool>
+{
+}
 
 /// Returns a `CommentFn` implementation that does nothing.
 fn no_comment<'x>() -> impl CommentFn<'x> {
@@ -708,7 +708,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
     fn inspect_ephemeral_annotations<'x>(
         &mut self,
         depth: usize,
-        annotations: impl Iterator<Item=IonResult<SymbolRef<'x>>>,
+        annotations: impl Iterator<Item = IonResult<SymbolRef<'x>>>,
     ) -> Result<()> {
         self.write_blank_offset_length_and_bytes(depth)?;
         self.with_style(ephemeral_annotations_style(), |out| {
@@ -727,8 +727,8 @@ impl<'a, 'b> IonInspector<'a, 'b> {
     /// how each annotation was encoded: as a SID (`$10`) or as inline UTF-8 bytes (`foo`).
     fn display_annotations_with_raw_encoding_comment<'x>(
         &mut self,
-        annotations: impl Iterator<Item=IonResult<SymbolRef<'x>>>,
-        raw_annotations: impl Iterator<Item=IonResult<RawSymbolRef<'x>>>,
+        annotations: impl Iterator<Item = IonResult<SymbolRef<'x>>>,
+        raw_annotations: impl Iterator<Item = IonResult<RawSymbolRef<'x>>>,
     ) -> Result<()> {
         let formatted_annotations = self.format_annotations(annotations)?;
         self.write_with_style(annotations_style(), formatted_annotations.as_str())?;
@@ -801,7 +801,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         value_delimiter: &str,
         closing_delimiter: &str,
         trailing_delimiter: &str,
-        nested_values: impl IntoIterator<Item=IonResult<LazyValue<'x, AnyEncoding>>>,
+        nested_values: impl IntoIterator<Item = IonResult<LazyValue<'x, AnyEncoding>>>,
         encoded_value: impl EncodedBinaryValue<'x, D>,
         value_comment_fn: impl CommentFn<'x>,
     ) -> Result<()> {
@@ -828,7 +828,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         value_delimiter: &str,
         closing_delimiter: &str,
         trailing_delimiter: &str,
-        nested_values: impl IntoIterator<Item=IonResult<LazyValue<'x, AnyEncoding>>>,
+        nested_values: impl IntoIterator<Item = IonResult<LazyValue<'x, AnyEncoding>>>,
         value_comment_fn: impl CommentFn<'x>,
     ) -> Result<()> {
         self.write_blank_offset_length_and_bytes(depth)?;
@@ -851,7 +851,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         &mut self,
         depth: usize,
         value_delimiter: &str,
-        nested_values: impl IntoIterator<Item=IonResult<LazyValue<'x, AnyEncoding>>>,
+        nested_values: impl IntoIterator<Item = IonResult<LazyValue<'x, AnyEncoding>>>,
         mut value_comment_fn: impl CommentFn<'x>,
     ) -> Result<()> {
         let mut has_printed_skip_message = false;
@@ -1227,7 +1227,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
 
     fn format_annotations<'x>(
         &self,
-        annotations: impl Iterator<Item=IonResult<SymbolRef<'x>>>,
+        annotations: impl Iterator<Item = IonResult<SymbolRef<'x>>>,
     ) -> Result<String> {
         use std::fmt::Write;
         let mut formatted_annotations = String::new();

--- a/src/bin/ion/commands/inspect.rs
+++ b/src/bin/ion/commands/inspect.rs
@@ -193,10 +193,10 @@ const BYTES_PER_ROW: usize = 8;
 /// otherwise.
 trait CommentFn<'x>: FnMut(&mut CommandOutput, LazyValue<'x, AnyEncoding>) -> Result<bool> {}
 
-impl<'x, F> CommentFn<'x> for F where
-    F: FnMut(&mut CommandOutput, LazyValue<'x, AnyEncoding>) -> Result<bool>
-{
-}
+impl<'x, F> CommentFn<'x> for F
+where
+    F: FnMut(&mut CommandOutput, LazyValue<'x, AnyEncoding>) -> Result<bool>,
+{}
 
 /// Returns a `CommentFn` implementation that does nothing.
 fn no_comment<'x>() -> impl CommentFn<'x> {
@@ -620,25 +620,6 @@ impl<'a, 'b> IonInspector<'a, 'b> {
             }
         }
     }
-    // fn inspect_struct(
-    //     &mut self,
-    //     depth: usize,
-    //     delimiter: &str,
-    //     struct_: LazyStruct<'_, AnyEncoding>,
-    // ) -> Result<()> {
-    //     match struct_.expanded().source() {
-    //         ExpandedStructSource::ValueLiteral(raw_struct) => {
-    //             use LazyRawValueKind::*;
-    //             match raw_struct.as_value().kind() {
-    //                 Binary_1_0(v) =>
-    //                     self.inspect_literal_struct(depth, delimiter, struct_, v),
-    //                 Binary_1_1(v) => self.inspect_literal_struct(depth, delimiter, struct_, v),
-    //                 Text_1_0(_) | Text_1_1(_) => unreachable!("text value"),
-    //             }
-    //         }
-    //         ExpandedStructSource::Template(_, _, _) => self.inspect_ephemeral_struct(depth, delimiter, struct_)
-    //     }
-    // }
 
     fn inspect_symbol_table(&mut self, struct_: LazyStruct<'_, AnyEncoding>) -> Result<()> {
         let value = struct_.as_value();
@@ -727,7 +708,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
     fn inspect_ephemeral_annotations<'x>(
         &mut self,
         depth: usize,
-        annotations: impl Iterator<Item = IonResult<SymbolRef<'x>>>,
+        annotations: impl Iterator<Item=IonResult<SymbolRef<'x>>>,
     ) -> Result<()> {
         self.write_blank_offset_length_and_bytes(depth)?;
         self.with_style(ephemeral_annotations_style(), |out| {
@@ -746,8 +727,8 @@ impl<'a, 'b> IonInspector<'a, 'b> {
     /// how each annotation was encoded: as a SID (`$10`) or as inline UTF-8 bytes (`foo`).
     fn display_annotations_with_raw_encoding_comment<'x>(
         &mut self,
-        annotations: impl Iterator<Item = IonResult<SymbolRef<'x>>>,
-        raw_annotations: impl Iterator<Item = IonResult<RawSymbolRef<'x>>>,
+        annotations: impl Iterator<Item=IonResult<SymbolRef<'x>>>,
+        raw_annotations: impl Iterator<Item=IonResult<RawSymbolRef<'x>>>,
     ) -> Result<()> {
         let formatted_annotations = self.format_annotations(annotations)?;
         self.write_with_style(annotations_style(), formatted_annotations.as_str())?;
@@ -820,7 +801,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         value_delimiter: &str,
         closing_delimiter: &str,
         trailing_delimiter: &str,
-        nested_values: impl IntoIterator<Item = IonResult<LazyValue<'x, AnyEncoding>>>,
+        nested_values: impl IntoIterator<Item=IonResult<LazyValue<'x, AnyEncoding>>>,
         encoded_value: impl EncodedBinaryValue<'x, D>,
         value_comment_fn: impl CommentFn<'x>,
     ) -> Result<()> {
@@ -847,7 +828,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         value_delimiter: &str,
         closing_delimiter: &str,
         trailing_delimiter: &str,
-        nested_values: impl IntoIterator<Item = IonResult<LazyValue<'x, AnyEncoding>>>,
+        nested_values: impl IntoIterator<Item=IonResult<LazyValue<'x, AnyEncoding>>>,
         value_comment_fn: impl CommentFn<'x>,
     ) -> Result<()> {
         self.write_blank_offset_length_and_bytes(depth)?;
@@ -870,7 +851,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         &mut self,
         depth: usize,
         value_delimiter: &str,
-        nested_values: impl IntoIterator<Item = IonResult<LazyValue<'x, AnyEncoding>>>,
+        nested_values: impl IntoIterator<Item=IonResult<LazyValue<'x, AnyEncoding>>>,
         mut value_comment_fn: impl CommentFn<'x>,
     ) -> Result<()> {
         let mut has_printed_skip_message = false;
@@ -1246,7 +1227,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
 
     fn format_annotations<'x>(
         &self,
-        annotations: impl Iterator<Item = IonResult<SymbolRef<'x>>>,
+        annotations: impl Iterator<Item=IonResult<SymbolRef<'x>>>,
     ) -> Result<String> {
         use std::fmt::Write;
         let mut formatted_annotations = String::new();

--- a/src/bin/ion/commands/inspect.rs
+++ b/src/bin/ion/commands/inspect.rs
@@ -3,10 +3,10 @@ use std::io::Write;
 use std::str::FromStr;
 
 use anyhow::{bail, Context, Result};
-use clap::{Arg, ArgMatches, Command};
-use ion_rs::v1_0::{LazyRawBinaryValue, RawValueRef};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use clap::builder::ValueParser;
+use ion_rs::v1_0::{EncodedBinaryValue, RawValueRef};
 use ion_rs::*;
-
 use crate::commands::{CommandIo, IonCliCommand, WithIonCliArgument};
 
 // The `inspect` command uses the `termcolor` crate to colorize its text when STDOUT is a TTY.
@@ -18,6 +18,14 @@ use crate::output::CommandOutput;
 pub struct InspectCommand;
 
 impl IonCliCommand for InspectCommand {
+    fn is_stable(&self) -> bool {
+        true
+    }
+
+    fn is_porcelain(&self) -> bool {
+        true
+    }
+
     fn name(&self) -> &'static str {
         "inspect"
     }
@@ -27,14 +35,6 @@ impl IonCliCommand for InspectCommand {
 Its output prioritizes human readability and is likely to change
 between versions. Stable output for programmatic use cases is a
 non-goal."
-    }
-
-    fn is_stable(&self) -> bool {
-        true
-    }
-
-    fn is_porcelain(&self) -> bool {
-        true
     }
 
     fn configure_args(&self, command: Command) -> Command {
@@ -76,6 +76,20 @@ value start after `--skip-bytes`.
 ",
                     ),
             )
+            .arg(
+                Arg::new("hide-expansion")
+                    .long("hide-expansion")
+                    .default_value("false")
+                    .action(ArgAction::SetTrue)
+                    .value_parser(ValueParser::bool())
+                    .help("Do not show values produced by macro evaluation.")
+                    .long_help("When specified, the inspector will display e-expressions
+(that is: data stream macro invocations) but will not show values produced
+ by evaluating those e-expressions. If an e-expression produces a 'system'
+ value that modifies the encoding context (that is: a symbol table or
+ encoding directive), that value will still be displayed."
+                    ),
+            )
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
@@ -109,10 +123,12 @@ value start after `--skip-bytes`.
             limit_bytes = usize::MAX;
         }
 
+        let hide_expansion = args.get_flag("hide-expansion");
+
         CommandIo::new(args).for_each_input(|output, input| {
             let input_name = input.name().to_owned();
             let input = input.into_source();
-            inspect_input(&input_name, input, output, bytes_to_skip, limit_bytes)
+            inspect_input(&input_name, input, output, bytes_to_skip, limit_bytes, hide_expansion)
         })
     }
 }
@@ -125,9 +141,10 @@ fn inspect_input<Input: IonInput>(
     output: &mut CommandOutput,
     bytes_to_skip: usize,
     limit_bytes: usize,
+    hide_expansion: bool,
 ) -> Result<()> {
     let mut reader = SystemReader::new(AnyEncoding, input);
-    let mut inspector = IonInspector::new(output, bytes_to_skip, limit_bytes)?;
+    let mut inspector = IonInspector::new(output, bytes_to_skip, limit_bytes, hide_expansion)?;
     // This inspects all values at the top level, recursing as necessary.
     inspector
         .inspect_top_level(&mut reader)
@@ -152,6 +169,7 @@ struct IonInspector<'a, 'b> {
     bytes_to_skip: usize,
     skip_complete: bool,
     limit_bytes: usize,
+    hide_expansion: bool,
     // Text Ion writer for formatting scalar values
     text_writer: v1_0::RawTextWriter<Vec<u8>>,
 }
@@ -167,10 +185,10 @@ const BYTES_PER_ROW: usize = 8;
 /// otherwise.
 trait CommentFn<'x>: FnMut(&mut CommandOutput, LazyValue<'x, AnyEncoding>) -> Result<bool> {}
 
-impl<'x, F> CommentFn<'x> for F where
-    F: FnMut(&mut CommandOutput, LazyValue<'x, AnyEncoding>) -> Result<bool>
-{
-}
+impl<'x, F> CommentFn<'x> for F
+where
+    F: FnMut(&mut CommandOutput, LazyValue<'x, AnyEncoding>) -> Result<bool>,
+{}
 
 /// Returns a `CommentFn` implementation that does nothing.
 fn no_comment<'x>() -> impl CommentFn<'x> {
@@ -182,12 +200,14 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         out: &'a mut CommandOutput<'b>,
         bytes_to_skip: usize,
         limit_bytes: usize,
+        hide_expansion: bool,
     ) -> IonResult<IonInspector<'a, 'b>> {
         let text_writer = WriteConfig::<v1_0::Text>::new(TextFormat::Compact)
             .build_raw_writer(Vec::with_capacity(TEXT_WRITER_INITIAL_BUFFER_SIZE))?;
         let inspector = IonInspector {
             output: out,
             bytes_to_skip,
+            hide_expansion,
             skip_complete: bytes_to_skip == 0,
             limit_bytes,
             text_writer,
@@ -201,8 +221,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
             Text_1_0 | Text_1_1 => {
                 bail!("`inspect` does not support text Ion streams.");
             }
-            Binary_1_0 => Ok(()),
-            Binary_1_1 => bail!("`inspect` does not yet support binary Ion v1.1"),
+            Binary_1_0 | Binary_1_1 => Ok(()),
             // `IonEncoding` is #[non_exhaustive]
             _ => bail!("`inspect does not yet support {}", encoding.name()),
         }
@@ -214,24 +233,29 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         reader: &mut SystemReader<AnyEncoding, Input>,
     ) -> Result<()> {
         const TOP_LEVEL_DEPTH: usize = 0;
+        use ExpandedStreamItem::*;
 
         let mut is_first_item = true;
         let mut has_printed_skip_message = false;
         loop {
-            let item = reader.next_item()?;
-            let is_last_item = matches!(item, SystemStreamItem::EndOfStream(_));
-            item.raw_stream_item()
-                .map(|i| self.confirm_encoding_is_supported(i.encoding()))
-                .unwrap_or(Ok(()))?;
-
             if is_first_item {
                 self.write_table_header()?;
             }
 
+            let expr = reader.next_expanded_item()?;
+
+            let maybe_raw_item = expr.raw_item();
+            // If this item is backed by bytes on the wire, make sure we support the encoding.
+            if let Some(raw_item) = maybe_raw_item {
+                self.confirm_encoding_is_supported(raw_item.encoding())?;
+            }
+
+            let is_last_item = matches!(expr, EndOfStream(_));
+
             match self.select_action(
                 TOP_LEVEL_DEPTH,
                 &mut has_printed_skip_message,
-                &item.raw_stream_item(),
+                &maybe_raw_item,
                 "stream items",
                 "ending",
             )? {
@@ -243,28 +267,36 @@ impl<'a, 'b> IonInspector<'a, 'b> {
                 InspectorAction::LimitReached => break,
             }
 
-            if !is_first_item && !is_last_item {
+            if !is_first_item && !is_last_item && !expr.is_ephemeral() {
                 // If this item is neither the first nor last in the stream, print a row separator.
                 write!(self.output, "{ROW_SEPARATOR}")?;
             }
 
-            match item {
-                SystemStreamItem::SymbolTable(lazy_struct) => {
+            match expr {
+                EExp(eexp) => {
+                    self.inspect_eexp(0, eexp)?;
+                }
+                SymbolTable(lazy_struct) => {
                     self.inspect_symbol_table(lazy_struct)?;
                 }
-                SystemStreamItem::Value(lazy_value) => {
-                    self.inspect_value(0, "", lazy_value, no_comment())?;
+                EncodingDirective(lazy_sexp) => {
+                    self.inspect_value(0, "", lazy_sexp.as_value(), no_comment())?;
                 }
-                SystemStreamItem::VersionMarker(marker) => {
+                Value(lazy_value) => {
+                    if lazy_value.expanded().is_ephemeral() && self.hide_expansion {
+                        // The user has requested that we not show ephemeral values from macros.
+                    } else {
+                        self.inspect_value(0, "", lazy_value, no_comment())?;
+                    }
+                }
+                VersionMarker(marker) => {
                     self.confirm_encoding_is_supported(marker.encoding())?;
                     self.inspect_ivm(marker)?;
                 }
-                SystemStreamItem::EndOfStream(_) => {
+                EndOfStream(end) => {
+                    self.inspect_end_of_stream(end.range().start)?;
                     break;
                 }
-                // `SystemStreamItem` is marked `#[non_exhaustive]`, so this branch is needed.
-                // The arms above cover all of the existing variants at the time of writing.
-                _ => unimplemented!("a new SystemStreamItem variant was added"),
             }
 
             is_first_item = false;
@@ -343,12 +375,13 @@ impl<'a, 'b> IonInspector<'a, 'b> {
             )],
         );
         self.write_offset_length_and_bytes(
+            0,
             marker.range().start,
             BINARY_IVM_LENGTH,
             &mut formatter,
         )?;
         self.with_style(BytesKind::VersionMarker.style(), |out| {
-            let (major, minor) = marker.version();
+            let (major, minor) = marker.major_minor();
             write!(out, "$ion_{major}_{minor}")?;
             Ok(())
         })?;
@@ -361,6 +394,62 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         Ok(())
     }
 
+    fn inspect_end_of_stream(&mut self, position: usize) -> Result<()> {
+        let mut empty_bytes = BytesFormatter::new(BYTES_PER_ROW, vec![]);
+        self.newline()?;
+        self.write_offset_length_and_bytes(0, position, "", &mut empty_bytes)?;
+        self.write_with_style(comment_style(), "// End of stream")
+    }
+
+    fn inspect_eexp(
+        &mut self,
+        depth: usize,
+        eexp: EExpression<AnyEncoding>,
+    ) -> Result<()> {
+        let mut formatter = BytesFormatter::new(
+            BYTES_PER_ROW,
+            vec![
+                // TODO: Add methods to EExpression that allow nuanced access to its encoded spans
+                // TODO: Length-prefixed and multibyte e-expression addresses
+                IonBytes::new(BytesKind::MacroId, &eexp.span().bytes()[0..1]),
+            ],
+        );
+        self.newline()?;
+        self.write_offset_length_and_bytes(depth, eexp.range().start, eexp.span().len(), &mut formatter)?;
+        self.with_style(eexp_style(), |out| {
+            write!(out, "(:{}", eexp.invoked_macro().id_text())?;
+            Ok(())
+        })?;
+        for (param, arg_result) in eexp.invoked_macro().signature().parameters().iter().zip(eexp.arguments()) {
+            let arg = arg_result?;
+            match arg {
+                ValueExpr::ValueLiteral(value) => {
+                    self.inspect_value(depth + 1, "", LazyValue::from(value), |out, _value| {
+                        write!(out, " // {}", param.name())?;
+                        Ok(true)
+                    })?;
+                }
+                ValueExpr::MacroInvocation(invocation) => {
+                    use MacroExprKind::*;
+                    match invocation.kind() {
+                        EExp(eexp_arg) => self.inspect_eexp(depth + 1, eexp_arg)?,
+                        EExpArgGroup(_) => todo!("e-exp arg groups"),
+                        TemplateMacro(_) => unreachable!("e-exp args by definition cannot be template invocations"),
+                    }
+                }
+            }
+        }
+        self.write_text_only_line(depth, eexp_style(), ")")?;
+        Ok(())
+    }
+
+    fn write_text_only_line(&mut self, depth: usize, style: ColorSpec, text: &str) -> Result<()> {
+        self.newline()?;
+        self.write_blank_offset_length_and_bytes(depth)?;
+        self.write_indentation(depth)?;
+        self.write_with_style(style, text)
+    }
+
     /// Inspects all values (however deeply nested) starting at the current level.
     fn inspect_value<'x>(
         &mut self,
@@ -369,12 +458,12 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         value: LazyValue<'x, AnyEncoding>,
         comment_fn: impl CommentFn<'x>,
     ) -> Result<()> {
-        use ValueRef::*;
         self.newline()?;
         if value.has_annotations() {
             self.inspect_annotations(depth, value)?;
             self.newline()?;
         }
+        use ValueRef::*;
         match value.read()? {
             SExp(sexp) => self.inspect_sexp(depth, delimiter, sexp),
             List(list) => self.inspect_list(depth, delimiter, list),
@@ -393,26 +482,23 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         comment_fn: impl CommentFn<'x>,
     ) -> Result<()> {
         use ExpandedValueSource::*;
-        let value_literal = match value.expanded().source() {
-            ValueLiteral(value_literal) => value_literal,
-            // In Ion 1.0, there are no template values or constructed values so we can defer
-            // implementing these.
-            Template(_, _) => {
-                todo!("Ion 1.1 template values")
+        match value.expanded().source() {
+            // If the value is backed by an encoded literal AND that literal wasn't passed as an
+            // argument to an e-expression, inspect the encoded value.
+            ValueLiteral(value_literal) if !value.expanded().is_parameter() => {
+                use LazyRawValueKind::*;
+                match value_literal.kind() {
+                    Binary_1_0(bin_val) => {
+                        self.inspect_literal_scalar(depth, delimiter, value, bin_val, comment_fn)
+                    }
+                    Binary_1_1(bin_val) => self.inspect_literal_scalar(depth, delimiter, value, bin_val, comment_fn),
+                    Text_1_0(_) | Text_1_1(_) => unreachable!("text value"),
+                }
             }
-            Constructed(_, _) => {
-                todo!("Ion 1.1 constructed values")
+            // Otherwise, display the value without showing its encoding (if any)
+            _ => {
+                self.inspect_ephemeral_scalar(depth, delimiter, value, comment_fn)
             }
-        };
-
-        use LazyRawValueKind::*;
-        // Check what encoding this is. At the moment, only binary Ion 1.0 is supported.
-        match value_literal.kind() {
-            Binary_1_0(bin_val) => {
-                self.inspect_binary_1_0_scalar(depth, delimiter, value, bin_val, comment_fn)
-            }
-            Binary_1_1(_) => todo!("Binary Ion 1.1 scalars"),
-            Text_1_0(_) | Text_1_1(_) => unreachable!("text value"),
         }
     }
 
@@ -426,16 +512,24 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         sexp: LazySExp<'_, AnyEncoding>,
     ) -> Result<()> {
         use ExpandedSExpSource::*;
-        let raw_sexp = match sexp.expanded().source() {
-            ValueLiteral(raw_sexp) => raw_sexp,
-            Template(_, _, _, _) => todo!("Ion 1.1 template SExp"),
-        };
-
-        use LazyRawSExpKind::*;
-        match raw_sexp.kind() {
-            Text_1_0(_) | Text_1_1(_) => unreachable!("text value"),
-            Binary_1_0(v) => self.inspect_binary_1_0_sexp(depth, delimiter, sexp, v),
-            Binary_1_1(_) => todo!("Binary Ion 1.1 SExp"),
+        match sexp.expanded().source() {
+            ValueLiteral(raw_sexp) => {
+                use LazyRawSExpKind::*;
+                match raw_sexp.kind() {
+                    Text_1_0(_) | Text_1_1(_) => unreachable!("text value"),
+                    Binary_1_0(v) => self.inspect_literal_sexp(depth, delimiter, sexp, v.as_value()),
+                    Binary_1_1(v) => self.inspect_literal_sexp(depth, delimiter, sexp, v.as_value()),
+                }
+            }
+            Template(_, _element) => self.inspect_ephemeral_sequence(
+                depth,
+                "(",
+                "",
+                ")",
+                delimiter,
+                sexp,
+                no_comment(),
+            )
         }
     }
 
@@ -449,16 +543,46 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         list: LazyList<'_, AnyEncoding>,
     ) -> Result<()> {
         use ExpandedListSource::*;
-        let raw_list = match list.expanded().source() {
-            ValueLiteral(raw_list) => raw_list,
-            Template(_, _, _, _) => todo!("Ion 1.1 template List"),
-        };
-
-        use LazyRawListKind::*;
-        match raw_list.kind() {
-            Text_1_0(_) | Text_1_1(_) => unreachable!("text value"),
-            Binary_1_0(v) => self.inspect_binary_1_0_list(depth, delimiter, list, v),
-            Binary_1_1(_) => todo!("Binary Ion 1.1 List"),
+        match list.expanded().source() {
+            ValueLiteral(raw_list) => {
+                use LazyRawListKind::*;
+                match raw_list.kind() {
+                    Text_1_0(_) | Text_1_1(_) => unreachable!("text value"),
+                    Binary_1_0(v) => {
+                        self.inspect_literal_sequence(
+                            depth,
+                            "[",
+                            ",",
+                            "]",
+                            delimiter,
+                            list.iter(),
+                            v.as_value(),
+                            no_comment(),
+                        )
+                    }
+                    Binary_1_1(v) => {
+                        self.inspect_literal_sequence(
+                            depth,
+                            "[",
+                            ",",
+                            "]",
+                            delimiter,
+                            list.iter(),
+                            v.as_value(),
+                            no_comment(),
+                        )
+                    }
+                }
+            }
+            Template(_, _element) => self.inspect_ephemeral_sequence(
+                depth,
+                "[",
+                ",",
+                "]",
+                delimiter,
+                list.iter(),
+                no_comment(),
+            )
         }
     }
 
@@ -471,20 +595,38 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         delimiter: &str,
         struct_: LazyStruct<'_, AnyEncoding>,
     ) -> Result<()> {
-        let raw_struct = match struct_.expanded().source() {
-            ExpandedStructSource::ValueLiteral(raw_struct) => raw_struct,
-            ExpandedStructSource::Template(_, _, _, _, _) => todo!("Ion 1.1 template Struct"),
-        };
-
-        use LazyRawValueKind::*;
-        match raw_struct.as_value().kind() {
-            Binary_1_0(v) => {
-                self.inspect_binary_1_0_struct(depth, delimiter, struct_, raw_struct, v)
+        match struct_.expanded().source() {
+            ExpandedStructSource::ValueLiteral(raw_struct) => {
+                use LazyRawValueKind::*;
+                match raw_struct.as_value().kind() {
+                    Binary_1_0(v) =>
+                        self.inspect_literal_struct(depth, delimiter, struct_, v),
+                    Binary_1_1(v) => self.inspect_literal_struct(depth, delimiter, struct_, v),
+                    Text_1_0(_) | Text_1_1(_) => unreachable!("text value"),
+                }
             }
-            Binary_1_1(_) => todo!("Binary Ion 1.1 Struct"),
-            Text_1_0(_) | Text_1_1(_) => unreachable!("text value"),
+            ExpandedStructSource::Template(_, _, _) => self.inspect_ephemeral_struct(depth, delimiter, struct_)
         }
     }
+    // fn inspect_struct(
+    //     &mut self,
+    //     depth: usize,
+    //     delimiter: &str,
+    //     struct_: LazyStruct<'_, AnyEncoding>,
+    // ) -> Result<()> {
+    //     match struct_.expanded().source() {
+    //         ExpandedStructSource::ValueLiteral(raw_struct) => {
+    //             use LazyRawValueKind::*;
+    //             match raw_struct.as_value().kind() {
+    //                 Binary_1_0(v) =>
+    //                     self.inspect_literal_struct(depth, delimiter, struct_, v),
+    //                 Binary_1_1(v) => self.inspect_literal_struct(depth, delimiter, struct_, v),
+    //                 Text_1_0(_) | Text_1_1(_) => unreachable!("text value"),
+    //             }
+    //         }
+    //         ExpandedStructSource::Template(_, _, _) => self.inspect_ephemeral_struct(depth, delimiter, struct_)
+    //     }
+    // }
 
     fn inspect_symbol_table(&mut self, struct_: LazyStruct<'_, AnyEncoding>) -> Result<()> {
         let value = struct_.as_value();
@@ -494,32 +636,111 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         }
         let raw_struct = match struct_.expanded().source() {
             ExpandedStructSource::ValueLiteral(raw_struct) => raw_struct,
-            ExpandedStructSource::Template(_, _, _, _, _) => todo!("Ion 1.1 template symbol table"),
+            ExpandedStructSource::Template(_, _, _) => todo!("Ion 1.1 template symbol table"),
         };
 
         use LazyRawValueKind::*;
         match raw_struct.as_value().kind() {
-            Binary_1_0(v) => self.inspect_binary_1_0_symbol_table(struct_, raw_struct, v),
-            Binary_1_1(_) => todo!("Binary Ion 1.1 symbol table"),
+            Binary_1_0(v) => self.inspect_literal_symbol_table(struct_, raw_struct, v),
+            Binary_1_1(v) => self.inspect_literal_symbol_table(struct_, raw_struct, v),
             Text_1_0(_) | Text_1_1(_) => unreachable!("text value"),
         }
     }
 
+    /// Determines the source of the annotations on the provided value (if any) and adds them to the
+    /// output table.
+    ///
+    /// If the annotations are from a stream literal, their color-coded encoding bytes will also be
+    /// displayed.
     fn inspect_annotations(&mut self, depth: usize, value: LazyValue<AnyEncoding>) -> Result<()> {
-        let raw_value = match value.expanded().source() {
-            ExpandedValueSource::ValueLiteral(raw_value) => raw_value,
-            ExpandedValueSource::Template(_, _) => todo!("Ion 1.1 template value annotations"),
-            ExpandedValueSource::Constructed(_, _) => {
-                todo!("Ion 1.1 constructed value annotations")
-            }
-        };
-
-        use LazyRawValueKind::*;
-        match raw_value.kind() {
-            Binary_1_0(v) => self.inspect_binary_1_0_annotations(depth, value, v),
-            Binary_1_1(_) => todo!("Binary Ion 1.1 annotations"),
-            Text_1_0(_) | Text_1_1(_) => unreachable!("text value"),
+        if !value.has_annotations() {
+            return Ok(());
         }
+        match value.expanded().source() {
+            ExpandedValueSource::ValueLiteral(raw_value) => {
+                use LazyRawValueKind::*;
+                match raw_value.kind() {
+                    Binary_1_0(v) => self.inspect_literal_annotations(depth, value, v),
+                    Binary_1_1(v) => self.inspect_literal_annotations(depth, value, v),
+                    Text_1_0(_) | Text_1_1(_) => unreachable!("text value"),
+                }
+            }
+            ExpandedValueSource::Template(_env, element) => {
+                self.inspect_ephemeral_annotations(depth, element.annotations().iter().map(|s| Ok(SymbolRef::from(s))))
+            }
+            ExpandedValueSource::Constructed(annotations, _) => {
+                self.inspect_ephemeral_annotations(depth, annotations.iter().copied().map(|s| Ok(s.into())))
+            }
+            ExpandedValueSource::SingletonEExp(eexp) => {
+                self.inspect_ephemeral_annotations(depth, eexp.require_singleton_annotations().map(|s| Ok(s.into())))
+            }
+        }
+    }
+
+    fn inspect_literal_annotations<'x, D: Decoder>(
+        &mut self,
+        depth: usize,
+        value: LazyValue<'x, AnyEncoding>,
+        encoded_value: impl EncodedBinaryValue<'x, D>,
+    ) -> Result<()> {
+        if !value.has_annotations() {
+            return Ok(());
+        }
+
+        let mut formatter = BytesFormatter::new(
+            BYTES_PER_ROW,
+            vec![
+                IonBytes::new(BytesKind::AnnotationsHeader, encoded_value.annotations_header_span().bytes()),
+                IonBytes::new(
+                    BytesKind::AnnotationsSequence,
+                    encoded_value.annotations_sequence_span().bytes(),
+                ),
+            ],
+        );
+        let range = encoded_value.annotations_span().range();
+        self.write_offset_length_and_bytes(depth, range.start, range.len(), &mut formatter)?;
+
+        self.display_annotations_with_raw_encoding_comment(value.annotations(), encoded_value.annotations())
+    }
+
+    fn inspect_ephemeral_annotations<'x>(&mut self,
+                                         depth: usize,
+                                         annotations: impl Iterator<Item=IonResult<SymbolRef<'x>>>,
+    ) -> Result<()> {
+        self.write_blank_offset_length_and_bytes(depth)?;
+        self.with_style(ephemeral_annotations_style(), |out| {
+            for annotation in annotations {
+                IoValueFormatter::new(&mut *out)
+                    .value_formatter()
+                    .format_symbol(annotation?)?;
+                write!(out, "::")?;
+            }
+            Ok(())
+        })?;
+        Ok(())
+    }
+
+    /// When the annotations' source is a stream literal, this method adds a text comment indicating
+    /// how each annotation was encoded: as a SID (`$10`) or as inline UTF-8 bytes (`foo`).
+    fn display_annotations_with_raw_encoding_comment<'x>(&mut self,
+                                                         annotations: impl Iterator<Item=IonResult<SymbolRef<'x>>>,
+                                                         raw_annotations: impl Iterator<Item=IonResult<RawSymbolRef<'x>>>,
+    ) -> Result<()> {
+        let formatted_annotations = self.format_annotations(annotations)?;
+        self.write_with_style(annotations_style(), formatted_annotations.as_str())?;
+        self.with_style(comment_style(), |out| {
+            write!(out, " // ")?;
+            for (index, raw_annotation) in raw_annotations.enumerate() {
+                if index > 0 {
+                    write!(out, ", ")?;
+                }
+                match raw_annotation? {
+                    RawSymbolRef::SymbolId(sid) => write!(out, "${sid}"),
+                    RawSymbolRef::Text(_) => write!(out, "<text>"),
+                }?;
+            }
+            Ok(())
+        })
     }
 
     // ===== Binary Ion 1.0 ======
@@ -529,106 +750,64 @@ impl<'a, 'b> IonInspector<'a, 'b> {
     // bytes.
     // This prints the container's offset, length, and header bytes, leaving the cursor positioned
     // at the beginning of the `Text Ion` column.
-    fn inspect_binary_1_0_container_header(
+    fn inspect_literal_container_header<'x, D: Decoder>(
         &mut self,
-        raw_value: v1_0::LazyRawBinaryValue,
+        depth: usize,
+        encoded_value: impl EncodedBinaryValue<'x, D>,
     ) -> Result<()> {
-        let encoding = raw_value.encoded_data();
-        let range = encoding.range();
-
-        let opcode_bytes: &[u8] = raw_value.encoded_data().opcode_span().bytes();
+        let opcode_bytes: &[u8] = encoded_value.value_opcode_span().bytes();
         let mut formatter = BytesFormatter::new(
             BYTES_PER_ROW,
             vec![
                 IonBytes::new(BytesKind::Opcode, opcode_bytes),
                 IonBytes::new(
                     BytesKind::TrailingLength,
-                    raw_value.encoded_data().trailing_length_span().bytes(),
+                    encoded_value.value_length_span().bytes(),
                 ),
             ],
         );
 
-        self.write_offset_length_and_bytes(range.start, range.len(), &mut formatter)
+        let range = encoded_value.value_span().range();
+        self.write_offset_length_and_bytes(depth, range.start, range.len(), &mut formatter)
     }
 
-    fn inspect_binary_1_0_sexp<'x>(
+    fn inspect_literal_sexp<'x, D: Decoder>(
         &mut self,
         depth: usize,
         delimiter: &str,
         sexp: LazySExp<'x, AnyEncoding>,
-        raw_sexp: v1_0::LazyRawBinarySExp<'x>,
+        encoded_value: impl EncodedBinaryValue<'x, D>,
     ) -> Result<()> {
-        self.inspect_binary_1_0_sequence(
+        self.inspect_literal_sequence(
             depth,
             "(",
             "",
             ")",
             delimiter,
             sexp.iter(),
-            raw_sexp,
-            raw_sexp.as_value(),
+            encoded_value,
             no_comment(),
         )
     }
 
-    fn inspect_binary_1_0_list<'x>(
-        &mut self,
-        depth: usize,
-        delimiter: &str,
-        list: LazyList<'x, AnyEncoding>,
-        raw_list: v1_0::LazyRawBinaryList<'x>,
-    ) -> Result<()> {
-        self.inspect_binary_1_0_sequence(
-            depth,
-            "[",
-            ",",
-            "]",
-            delimiter,
-            list.iter(),
-            raw_list,
-            raw_list.as_value(),
-            no_comment(),
-        )
-    }
-
-    fn inspect_binary_1_0_sequence<'x>(
+    fn inspect_literal_sequence<'x, D: Decoder>(
         &mut self,
         depth: usize,
         opening_delimiter: &str,
         value_delimiter: &str,
         closing_delimiter: &str,
         trailing_delimiter: &str,
-        nested_values: impl IntoIterator<Item = IonResult<LazyValue<'x, AnyEncoding>>>,
-        nested_raw_values: impl LazyRawSequence<'x, v1_0::Binary>,
-        raw_value: LazyRawBinaryValue,
-        mut value_comment_fn: impl CommentFn<'x>,
+        nested_values: impl IntoIterator<Item=IonResult<LazyValue<'x, AnyEncoding>>>,
+        encoded_value: impl EncodedBinaryValue<'x, D>,
+        value_comment_fn: impl CommentFn<'x>,
     ) -> Result<()> {
-        self.inspect_binary_1_0_container_header(raw_value)?;
-        self.write_indentation(depth)?;
+        self.inspect_literal_container_header(depth, encoded_value)?;
         self.with_style(text_ion_style(), |out| {
             write!(out, "{opening_delimiter}")?;
             Ok(())
         })?;
 
-        let mut has_printed_skip_message = false;
-        for (raw_value_res, value_res) in nested_raw_values.iter().zip(nested_values) {
-            let (raw_nested_value, nested_value) = (raw_value_res?, value_res?);
-            match self.select_action(
-                depth + 1,
-                &mut has_printed_skip_message,
-                &Some(raw_nested_value),
-                "values",
-                "stepping out",
-            )? {
-                InspectorAction::Skip => continue,
-                InspectorAction::Inspect => {}
-                InspectorAction::LimitReached => break,
-            }
-            self.inspect_value(depth + 1, value_delimiter, nested_value, no_comment())?;
-            self.output.set_color(&comment_style())?;
-            value_comment_fn(self.output, nested_value)?;
-            self.output.reset()?;
-        }
+        self.inspect_sequence_body(depth + 1, value_delimiter, nested_values, value_comment_fn)?;
 
         self.newline()?;
         self.write_blank_offset_length_and_bytes(depth)?;
@@ -636,6 +815,65 @@ impl<'a, 'b> IonInspector<'a, 'b> {
             write!(out, "{closing_delimiter}{trailing_delimiter}")?;
             Ok(())
         })
+    }
+
+    fn inspect_ephemeral_sequence<'x>(
+        &mut self,
+        depth: usize,
+        opening_delimiter: &str,
+        value_delimiter: &str,
+        closing_delimiter: &str,
+        trailing_delimiter: &str,
+        nested_values: impl IntoIterator<Item=IonResult<LazyValue<'x, AnyEncoding>>>,
+        value_comment_fn: impl CommentFn<'x>,
+    ) -> Result<()> {
+        self.write_blank_offset_length_and_bytes(depth)?;
+        self.with_style(ephemeral_value_style(), |out| {
+            write!(out, "{opening_delimiter}")?;
+            Ok(())
+        })?;
+
+        self.inspect_sequence_body(depth + 1, value_delimiter, nested_values, value_comment_fn)?;
+
+        self.newline()?;
+        self.write_blank_offset_length_and_bytes(depth)?;
+        self.with_style(ephemeral_value_style(), |out| {
+            write!(out, "{closing_delimiter}{trailing_delimiter}")?;
+            Ok(())
+        })
+    }
+
+    fn inspect_sequence_body<'x>(
+        &mut self,
+        depth: usize,
+        value_delimiter: &str,
+        nested_values: impl IntoIterator<Item=IonResult<LazyValue<'x, AnyEncoding>>>,
+        mut value_comment_fn: impl CommentFn<'x>,
+    ) -> Result<()> {
+        let mut has_printed_skip_message = false;
+        for value_res in nested_values {
+            let nested_value = value_res?;
+            // If this value is a literal in the stream, see if it is in the bounds of byte
+            // ranges we care about.
+
+            match self.select_action(
+                depth,
+                &mut has_printed_skip_message,
+                &nested_value.raw(),
+                "values",
+                "stepping out",
+            )? {
+                InspectorAction::Skip => continue,
+                InspectorAction::Inspect => {}
+                InspectorAction::LimitReached => break,
+            }
+
+            self.inspect_value(depth, value_delimiter, nested_value, no_comment())?;
+            self.output.set_color(&comment_style())?;
+            value_comment_fn(self.output, nested_value)?;
+            self.output.reset()?;
+        }
+        Ok(())
     }
 
     fn select_action<T: HasRange>(
@@ -663,7 +901,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         Ok(InspectorAction::Inspect)
     }
 
-    fn inspect_binary_1_0_field_name(
+    fn inspect_literal_field_name(
         &mut self,
         depth: usize,
         raw_name: LazyRawAnyFieldName,
@@ -678,8 +916,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
             BYTES_PER_ROW,
             vec![IonBytes::new(BytesKind::FieldId, raw_name_bytes)],
         );
-        self.write_offset_length_and_bytes(offset, length, &mut formatter)?;
-        self.write_indentation(depth)?;
+        self.write_offset_length_and_bytes(depth, offset, length, &mut formatter)?;
         self.with_style(field_id_style(), |out| {
             IoValueFormatter::new(out)
                 .value_formatter()
@@ -701,55 +938,40 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         })
     }
 
-    /// Inspects all values (however deeply nested) starting at the current level.
-    fn inspect_binary_1_0_field(
+    /// Inspects all values (however deeply nested) starting at the current field.
+    fn inspect_field(
         &mut self,
         depth: usize,
         field: LazyField<AnyEncoding>,
-        raw_field: LazyRawFieldExpr<AnyEncoding>,
     ) -> Result<()> {
-        let (raw_name, _raw_value) = raw_field.expect_name_value()?;
         let name = field.name()?;
-
-        self.inspect_binary_1_0_field_name(depth, raw_name, name)?;
+        if let Some(raw_name) = field.raw_name() {
+            self.inspect_literal_field_name(depth, raw_name, name)?;
+        } else {
+            self.newline()?;
+            self.write_blank_offset_length_and_bytes(depth)?;
+            self.with_style(ephemeral_field_id_style(), |out| {
+                IoValueFormatter::new(out)
+                    .value_formatter()
+                    .format_symbol(name)?;
+                Ok(())
+            })?;
+            write!(self.output, ": ")?;
+        };
         self.inspect_value(depth, ",", field.value(), no_comment())?;
         Ok(())
     }
 
-    fn inspect_binary_1_0_struct(
+    fn inspect_literal_struct<'x, D: Decoder>(
         &mut self,
         depth: usize,
         delimiter: &str,
         struct_: LazyStruct<AnyEncoding>,
-        raw_struct: LazyRawAnyStruct,
-        raw_value: LazyRawBinaryValue,
+        encoded_value: impl EncodedBinaryValue<'x, D>,
     ) -> Result<()> {
-        self.inspect_binary_1_0_container_header(raw_value)?;
-
-        self.write_indentation(depth)?;
-        self.with_style(text_ion_style(), |out| {
-            write!(out, "{{")?;
-            Ok(())
-        })?;
-        let mut has_printed_skip_message = false;
-        for (raw_field_result, field_result) in raw_struct.iter().zip(struct_.iter()) {
-            let field = field_result?;
-            let raw_field = raw_field_result?;
-            match self.select_action(
-                depth + 1,
-                &mut has_printed_skip_message,
-                &Some(raw_field),
-                "fields",
-                "stepping out",
-            )? {
-                InspectorAction::Skip => continue,
-                InspectorAction::Inspect => {
-                    self.inspect_binary_1_0_field(depth + 1, field, raw_field)?
-                }
-                InspectorAction::LimitReached => break,
-            }
-        }
-        // ===== Closing delimiter =====
+        self.inspect_literal_container_header(depth, encoded_value)?;
+        self.write_with_style(text_ion_style(), "{")?;
+        self.inspect_struct_body(depth, struct_)?;
         self.newline()?;
         self.write_blank_offset_length_and_bytes(depth)?;
         self.with_style(text_ion_style(), |out| {
@@ -758,18 +980,63 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         })
     }
 
-    fn inspect_binary_1_0_symbol_table(
+    fn inspect_ephemeral_struct<'x>(
+        &mut self,
+        depth: usize,
+        delimiter: &str,
+        struct_: LazyStruct<AnyEncoding>,
+    ) -> Result<()> {
+        self.write_blank_offset_length_and_bytes(depth)?;
+        self.with_style(ephemeral_value_style(), |out| {
+            write!(out, "{{")?;
+            Ok(())
+        })?;
+        self.inspect_struct_body(depth, struct_)?;
+        self.newline()?;
+        self.write_blank_offset_length_and_bytes(depth)?;
+        self.with_style(ephemeral_value_style(), |out| {
+            write!(out, "}}{delimiter}")?;
+            Ok(())
+        })
+    }
+
+    fn inspect_struct_body<'x>(
+        &mut self,
+        depth: usize,
+        struct_: LazyStruct<AnyEncoding>,
+    ) -> Result<()> {
+        let mut has_printed_skip_message: bool = false;
+        for field_result in struct_.iter() {
+            let field = field_result?;
+            match self.select_action(
+                depth + 1,
+                &mut has_printed_skip_message,
+                &field.range(),
+                "fields",
+                "stepping out",
+            )? {
+                InspectorAction::Skip => continue,
+                InspectorAction::Inspect => {
+                    self.inspect_field(depth + 1, field)?
+                }
+                InspectorAction::LimitReached => break,
+            }
+        }
+        Ok(())
+    }
+
+    fn inspect_literal_symbol_table<'x, D: Decoder>(
         &mut self,
         struct_: LazyStruct<AnyEncoding>,
         raw_struct: LazyRawAnyStruct,
-        raw_value: LazyRawBinaryValue,
+        encoded_value: impl EncodedBinaryValue<'x, D>,
     ) -> Result<()> {
         // The processing for a symbol table is very similar to that of a regular struct,
         // but with special handling defined for the `imports` and `symbols` fields when present.
         // Because symbol tables are always at the top level, there is no need for indentation.
         const TOP_LEVEL_DEPTH: usize = 0;
         self.newline()?;
-        self.inspect_binary_1_0_container_header(raw_value)?;
+        self.inspect_literal_container_header(TOP_LEVEL_DEPTH, encoded_value)?;
         self.with_style(text_ion_style(), |out| {
             write!(out, "{{")?;
             Ok(())
@@ -792,7 +1059,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
                 }
                 // TODO: if field.name()? == "imports" => {}
                 InspectorAction::Inspect => {
-                    self.inspect_binary_1_0_field(TOP_LEVEL_DEPTH + 1, field, raw_field)?
+                    self.inspect_field(TOP_LEVEL_DEPTH + 1, field)?
                 }
                 InspectorAction::LimitReached => break,
             }
@@ -814,7 +1081,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
     ) -> Result<()> {
         const SYMBOL_LIST_DEPTH: usize = 1;
         let (raw_name, raw_value) = raw_field.expect_name_value()?;
-        self.inspect_binary_1_0_field_name(SYMBOL_LIST_DEPTH, raw_name, field.name()?)?;
+        self.inspect_literal_field_name(SYMBOL_LIST_DEPTH, raw_name, field.name()?)?;
 
         let symbols_list = match field.value().read()? {
             ValueRef::List(list) => list,
@@ -830,13 +1097,16 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         let nested_raw_values = raw_symbols_list.iter();
         let nested_values = symbols_list.iter();
 
-        let LazyRawValueKind::Binary_1_0(raw_value) = raw_value.kind() else {
-            unreachable!("binary 1.0 encoding already confirmed");
-        };
-
         self.newline()?;
-        self.inspect_binary_1_0_container_header(raw_value)?;
-        self.write_indentation(SYMBOL_LIST_DEPTH)?;
+        match raw_value.kind() {
+            LazyRawValueKind::Binary_1_0(raw_value) => {
+                self.inspect_literal_container_header(SYMBOL_LIST_DEPTH, raw_value)?;
+            }
+            LazyRawValueKind::Binary_1_1(raw_value) => {
+                self.inspect_literal_container_header(SYMBOL_LIST_DEPTH, raw_value)?;
+            }
+            other_kind => unreachable!("binary encoding already confirmed; found {other_kind:?}"),
+        }
         self.with_style(text_ion_style(), |out| {
             write!(out, "[")?;
             Ok(())
@@ -887,113 +1157,102 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         })
     }
 
-    fn inspect_binary_1_0_annotations(
+    fn inspect_literal_scalar<'x, D: Decoder>(
         &mut self,
         depth: usize,
-        value: LazyValue<AnyEncoding>,
-        raw_value: LazyRawBinaryValue,
+        delimiter: &str,
+        value: LazyValue<'x, AnyEncoding>,
+        encoded_value: impl EncodedBinaryValue<'x, D>,
+        mut comment_fn: impl CommentFn<'x>,
     ) -> Result<()> {
-        let encoding = raw_value.encoded_annotations().unwrap();
-        let range = encoding.range();
+        let range = encoded_value.value_span().range();
 
-        let mut formatter = BytesFormatter::new(
-            BYTES_PER_ROW,
-            vec![
-                IonBytes::new(BytesKind::AnnotationsHeader, encoding.header_span().bytes()),
-                IonBytes::new(
-                    BytesKind::AnnotationsSequence,
-                    encoding.sequence_span().bytes(),
-                ),
-            ],
+        let opcode_bytes = IonBytes::new(BytesKind::Opcode, encoded_value.value_opcode_span());
+        let length_bytes = IonBytes::new(
+            BytesKind::TrailingLength,
+            encoded_value.value_length_span(),
         );
-        self.write_offset_length_and_bytes(range.start, range.len(), &mut formatter)?;
+        let body_bytes = IonBytes::new(BytesKind::ValueBody, encoded_value.value_body_span());
 
-        self.write_indentation(depth)?;
-        self.with_style(annotations_style(), |out| {
-            for annotation in value.annotations() {
-                IoValueFormatter::new(&mut *out)
-                    .value_formatter()
-                    .format_symbol(annotation?)?;
-                write!(out, "::")?;
-            }
+        let mut formatter =
+            BytesFormatter::new(BYTES_PER_ROW, vec![opcode_bytes, length_bytes, body_bytes]);
+
+        self.write_offset_length_and_bytes(depth, range.start, range.len(), &mut formatter)?;
+
+        let formatted_value = self.format_scalar_body(value)?;
+        self.with_style(text_ion_style(), |out| {
+            write!(out, "{formatted_value}{delimiter}")?;
             Ok(())
         })?;
-
         self.with_style(comment_style(), |out| {
-            write!(out, " // ")?;
-            for (index, raw_annotation) in raw_value.annotations().enumerate() {
-                if index > 0 {
-                    write!(out, ", ")?;
-                }
-                match raw_annotation? {
-                    RawSymbolRef::SymbolId(sid) => write!(out, "${sid}"),
-                    RawSymbolRef::Text(_) => write!(out, "<text>"),
+            let wrote_comment = comment_fn(out, value)?;
+            if let RawValueRef::Symbol(RawSymbolRef::SymbolId(symbol_id)) = encoded_value.read()? {
+                match wrote_comment {
+                    true => write!(out, " (${symbol_id})"),
+                    false => write!(out, " // ${symbol_id}"),
                 }?;
             }
             Ok(())
         })?;
 
+        while !formatter.is_empty() {
+            self.newline()?;
+            self.write_offset_length_and_bytes(depth, "", "", &mut formatter)?;
+        }
+
         Ok(())
     }
 
-    fn inspect_binary_1_0_scalar<'x>(
+    fn inspect_ephemeral_scalar<'x>(
         &mut self,
         depth: usize,
         delimiter: &str,
         value: LazyValue<'x, AnyEncoding>,
-        raw_value: LazyRawBinaryValue,
         mut comment_fn: impl CommentFn<'x>,
     ) -> Result<()> {
-        let encoding = raw_value.encoded_data();
-        let range = encoding.range();
+        self.write_blank_offset_length_and_bytes(depth)?;
+        let formatted_value = self.format_scalar_body(value)?;
+        let style = if let Some(variable) = value.expanded().variable() {
+            self.write_offset_length_and_bytes_comment(depth, "", "", variable.name())?;
+            ephemeral_value_style().set_underline(true).clone()
+        } else {
+            ephemeral_value_style().clone()
+        };
 
-        let opcode_bytes = IonBytes::new(BytesKind::Opcode, encoding.opcode_span().bytes());
-        let length_bytes = IonBytes::new(
-            BytesKind::TrailingLength,
-            encoding.trailing_length_span().bytes(),
-        );
-        let body_bytes = IonBytes::new(BytesKind::ValueBody, encoding.body_span().bytes());
+        self.with_style(style.clone(), |out| {
+            write!(out, "{formatted_value}")?;
+            Ok(())
+        })?;
+        self.write_with_style(style.clone().set_underline(false).clone(), delimiter)?;
+        self.with_style(comment_style(), |out| {
+            comment_fn(out, value)?;
+            Ok(())
+        })?;
+        Ok(())
+    }
 
-        let mut formatter =
-            BytesFormatter::new(BYTES_PER_ROW, vec![opcode_bytes, length_bytes, body_bytes]);
+    fn format_annotations<'x>(&self, annotations: impl Iterator<Item=IonResult<SymbolRef<'x>>>) -> Result<String> {
+        use std::fmt::Write;
+        let mut formatted_annotations = String::new();
+        for annotation in annotations {
+            write!(&mut formatted_annotations, "{}::", annotation?.text().unwrap_or("$0"))?;
+        }
+        Ok(formatted_annotations)
+    }
 
-        self.write_offset_length_and_bytes(range.start, range.len(), &mut formatter)?;
-        self.write_indentation(depth)?;
-
-        let style = text_ion_style();
-        self.output.set_color(&style)?;
+    fn format_scalar_body(
+        &mut self,
+        value: LazyValue<AnyEncoding>,
+    ) -> Result<String> {
         self.text_writer
             .write(value.read()?)
             .expect("failed to write text value to in-memory buffer")
             .flush()?;
 
-        let encoded = self.text_writer.output_mut();
-        if encoded.ends_with(&[b' ']) {
-            let _ = encoded.pop();
-        }
-        self.output
-            .write_all(self.text_writer.output().as_slice())?;
+        let encoded_bytes = self.text_writer.output_mut().trim_ascii_end();
+        let formatted_body = std::str::from_utf8(encoded_bytes)?.to_owned();
         self.text_writer.output_mut().clear();
-        self.output.write_all(delimiter.as_bytes())?;
-        self.output.reset()?;
-
-        self.output.set_color(&comment_style())?;
-        let wrote_comment = comment_fn(self.output, value)?;
-        if let RawValueRef::Symbol(RawSymbolRef::SymbolId(symbol_id)) = raw_value.read()? {
-            match wrote_comment {
-                true => write!(self.output, " (${symbol_id})"),
-                false => write!(self.output, " // ${symbol_id}"),
-            }?;
-        }
-        self.output.reset()?;
-
-        while !formatter.is_empty() {
-            self.newline()?;
-            self.write_offset_length_and_bytes("", "", &mut formatter)?;
-            self.write_indentation(depth)?;
-        }
-
-        Ok(())
+        Ok(formatted_body)
     }
 
     // ===== Table-writing methods =====
@@ -1035,11 +1294,35 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         })
     }
 
+    /// Prints the given `offset` and `length` in the first and second table columns.
+    /// The `offset` and `length` are typically `usize`, but can be anything that implements `Display`.
+    /// Prints the provided value in the `bytes` column using 'comment' styling.
+    fn write_offset_length_and_bytes_comment(
+        &mut self,
+        depth: usize,
+        offset: impl Display,
+        length: impl Display,
+        bytes: impl Display,
+    ) -> Result<()> {
+        write!(
+            self.output,
+            "{VERTICAL_LINE} {offset:12} {VERTICAL_LINE} {length:12} {VERTICAL_LINE} "
+        )?;
+        self.with_style(ephemeral_bytes_style(), |out| {
+            write!(out, "{bytes:>23}")?;
+            Ok(())
+        })?;
+        write!(self.output, " {VERTICAL_LINE} ")?;
+        self.write_indentation(depth)?;
+        Ok(())
+    }
+
     /// Prints the given `offset` and `length` in the first and second table columns, then uses the
     /// `formatter` to print a single row of hex-encoded bytes in the third column ("Binary Ion").
     /// The `offset` and `length` are typically `usize`, but can be anything that implements `Display`.
     fn write_offset_length_and_bytes(
         &mut self,
+        depth: usize,
         offset: impl Display,
         length: impl Display,
         formatter: &mut BytesFormatter,
@@ -1050,6 +1333,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         )?;
         formatter.write_row(self.output)?;
         write!(self.output, "{VERTICAL_LINE} ")?;
+        self.write_indentation(depth)?;
         Ok(())
     }
 
@@ -1057,8 +1341,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
     /// does not print a trailing newline, allowing the caller to populate the `Text Ion` column as needed.
     fn write_blank_offset_length_and_bytes(&mut self, depth: usize) -> Result<()> {
         let mut formatter = BytesFormatter::new(BYTES_PER_ROW, vec![]);
-        self.write_offset_length_and_bytes("", "", &mut formatter)?;
-        self.write_indentation(depth)
+        self.write_offset_length_and_bytes(depth, "", "", &mut formatter)
     }
 
     /// Prints a row with an ellipsis (`...`) in the first three columns, and a text Ion comment in
@@ -1103,8 +1386,30 @@ fn header_style() -> ColorSpec {
     style
 }
 
+fn eexp_style() -> ColorSpec {
+    let mut style = ColorSpec::new();
+    style.set_fg(Some(Color::Green)).set_bold(true).set_intense(true);
+    style
+}
+
 fn comment_style() -> ColorSpec {
     let mut style = ColorSpec::new();
+    style.set_dimmed(true);
+    style
+}
+
+fn ephemeral_bytes_style() -> ColorSpec {
+    eexp_style().set_dimmed(true).clone()
+}
+
+fn ephemeral_value_style() -> ColorSpec {
+    let mut style = ColorSpec::new();
+    style.set_fg(Some(Color::White));
+    style
+}
+
+fn ephemeral_field_id_style() -> ColorSpec {
+    let mut style = field_id_style();
     style.set_dimmed(true);
     style
 }
@@ -1127,9 +1432,14 @@ fn annotations_style() -> ColorSpec {
     style
 }
 
+fn ephemeral_annotations_style() -> ColorSpec {
+    annotations_style().set_dimmed(true).clone()
+}
+
 /// Kinds of encoding primitives found in a binary Ion stream.
 #[derive(Copy, Clone, Debug)]
 enum BytesKind {
+    MacroId,
     FieldId,
     Opcode,
     TrailingLength,
@@ -1151,7 +1461,12 @@ impl BytesKind {
                 .set_bold(true)
                 .set_fg(Some(Color::Rgb(0, 0, 0)))
                 .set_bg(Some(Color::Rgb(255, 255, 255))),
-
+            MacroId => color
+                .set_bold(true)
+                .set_fg(Some(Color::Rgb(0, 0, 0)))
+                .set_bg(Some(Color::Green))
+                .set_bold(true)
+                .set_intense(true),
             TrailingLength => color
                 .set_bold(true)
                 .set_underline(true)
@@ -1186,9 +1501,9 @@ struct IonBytes<'a> {
 }
 
 impl<'a> IonBytes<'a> {
-    fn new(kind: BytesKind, bytes: &'a [u8]) -> Self {
+    fn new(kind: BytesKind, bytes: impl Into<&'a [u8]>) -> Self {
         Self {
-            bytes,
+            bytes: bytes.into(),
             kind,
             bytes_written: 0,
         }

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -157,11 +157,6 @@ impl WithIonCliArgument for ClapCommand {
         )
     }
 
-    /// All commands automatically have the "unstable" opt-in flag. This makes it visible.
-    fn show_unstable_flag(self) -> Self {
-        self.mut_arg(UNSTABLE_FLAG, |arg| arg.hide(false))
-    }
-
     fn with_ion_version(self) -> Self {
         // TODO When this arg/feature becomes stable:
         //    Remove: show_unstable_flag()
@@ -195,6 +190,11 @@ impl WithIonCliArgument for ClapCommand {
                 // Do not show this flag in `help` for commands that don't take an `--input` flag.
                 .hide(!accepts_input),
         )
+    }
+
+    /// All commands automatically have the "unstable" opt-in flag. This makes it visible.
+    fn show_unstable_flag(self) -> Self {
+        self.mut_arg(UNSTABLE_FLAG, |arg| arg.hide(false))
     }
 }
 


### PR DESCRIPTION
* Upgrades the `ion-cli`'s dependency on `ion-rs` to [`v1.0.0-rc.7`](https://github.com/amazon-ion/ion-rust/releases/tag/v1.0.0-rc.7).
* Ion 1.1 value literals are recognized and their encodings displayed in the expected fashion.
* Ion 1.1 macro invocations (e-expressions) at the top level have their encodings displayed; the ephemeral values they produce follow them in a dimmed font.
* E-expression arguments have comments showing which macro parameter they correspond to
* Ephemeral values use the binary encoding column to indicate which parameter variable was backing the corresponding application value.
* This implementation does not yet support displaying e-expressions nested inside containers.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
