### PR TITLE
Set a version for `lowcharts` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ infer = "0.15.0"
 ion-rs = { version = "1.0.0-rc.7", features = ["experimental", "experimental-ion-hash"] }
 tempfile = "3.2.0"
 ion-schema = "0.10.0"
-lowcharts = "*"
+lowcharts = "0.5.8"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = { version = "1.0.81", features = ["arbitrary_precision", "preserve_order"] }
 base64 = "0.21.1"


### PR DESCRIPTION
Prior to this PR, our `lowcharts` dependency had a version of `*` (wildcard/latest). This is not permitted for binaries published via `cargo` as it leads to breakages when the dependencies release new major versions.

This patch sets its version to the latest available.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
