### PR TITLE
Adds new model changes for scalar

### DIFF
--- a/code-gen-projects/schema/scalar.isl
+++ b/code-gen-projects/schema/scalar.isl
@@ -1,0 +1,4 @@
+type::{
+    name: scalar,
+    type: string
+}

--- a/src/bin/ion/commands/generate/generator.rs
+++ b/src/bin/ion/commands/generate/generator.rs
@@ -1,7 +1,7 @@
 use crate::commands::generate::context::CodeGenContext;
 use crate::commands::generate::model::{
     AbstractDataType, DataModelNode, FieldPresence, FieldReference, FullyQualifiedTypeReference,
-    StructureBuilder,
+    ScalarBuilder, StructureBuilder, WrappedScalarBuilder,
 };
 use crate::commands::generate::result::{
     invalid_abstract_data_type_error, invalid_abstract_data_type_raw_error, CodeGenResult,
@@ -287,6 +287,7 @@ impl<'a, L: Language + 'static> CodeGenerator<'a, L> {
             type_name,
             isl_type,
             &mut code_gen_context,
+            true,
         )?;
 
         // add this nested type to parent code gene context's current list of nested types
@@ -315,6 +316,7 @@ impl<'a, L: Language + 'static> CodeGenerator<'a, L> {
             isl_type_name,
             isl_type,
             &mut code_gen_context,
+            false,
         )?;
 
         // add the entire type store and the data model node into tera's context to be used to render template
@@ -336,6 +338,7 @@ impl<'a, L: Language + 'static> CodeGenerator<'a, L> {
         isl_type_name: &String,
         isl_type: &IslType,
         code_gen_context: &mut CodeGenContext,
+        is_nested_type: bool,
     ) -> CodeGenResult<DataModelNode> {
         self.current_type_fully_qualified_name
             .push(isl_type_name.to_case(Case::UpperCamel));
@@ -348,6 +351,14 @@ impl<'a, L: Language + 'static> CodeGenerator<'a, L> {
             .any(|it| matches!(it.constraint(), IslConstraintValue::Fields(_, _)))
         {
             self.build_structure_from_constraints(constraints, code_gen_context, isl_type)?
+        } else if constraints.iter().any(|it| matches!(it.constraint(), IslConstraintValue::Type(isl_type_ref) if isl_type_ref.name().as_str() != "list"
+                     && isl_type_ref.name().as_str() != "sexp"
+                     && isl_type_ref.name().as_str() != "struct")) {
+            if is_nested_type {
+                self.build_scalar_from_constraints(constraints, code_gen_context, isl_type)?
+            } else {
+                self.build_wrapped_scalar_from_constraints(constraints, code_gen_context, isl_type)?
+            }
         } else {
             todo!("Support for sequences, maps, scalars, and tuples not implemented yet.")
         };
@@ -455,6 +466,9 @@ impl<'a, L: Language + 'static> CodeGenerator<'a, L> {
         parent_isl_type: &IslType,
     ) -> CodeGenResult<AbstractDataType> {
         let mut structure_builder = StructureBuilder::default();
+        structure_builder
+            .name(self.current_type_fully_qualified_name.to_owned())
+            .source(parent_isl_type.to_owned());
         for constraint in constraints {
             match constraint.constraint() {
                 IslConstraintValue::Fields(struct_fields, is_closed) => {
@@ -479,17 +493,11 @@ impl<'a, L: Language + 'static> CodeGenerator<'a, L> {
                     }
                     // unwrap here is safe as the `current_abstract_data_type_builder` will either be initialized with default implementation
                     // or already initialized with a previous structure related constraint at this point.
-                    structure_builder
-                        .fields(fields)
-                        .source(parent_isl_type.to_owned())
-                        .is_closed(*is_closed)
-                        .name(self.current_type_fully_qualified_name.to_owned());
+                    structure_builder.fields(fields).is_closed(*is_closed);
                 }
                 IslConstraintValue::Type(_) => {
                     // by default fields aren't closed
-                    structure_builder
-                        .is_closed(false)
-                        .source(parent_isl_type.to_owned());
+                    structure_builder.is_closed(false);
                 }
                 _ => {
                     return invalid_abstract_data_type_error(
@@ -500,6 +508,76 @@ impl<'a, L: Language + 'static> CodeGenerator<'a, L> {
         }
 
         Ok(AbstractDataType::Structure(structure_builder.build()?))
+    }
+
+    /// Build wrapped scalar data type from constraints
+    fn build_wrapped_scalar_from_constraints(
+        &mut self,
+        constraints: &[IslConstraint],
+        code_gen_context: &mut CodeGenContext,
+        parent_isl_type: &IslType,
+    ) -> CodeGenResult<AbstractDataType> {
+        let mut wrapped_scalar_builder = WrappedScalarBuilder::default();
+        wrapped_scalar_builder
+            .name(self.current_type_fully_qualified_name.to_owned())
+            .source(parent_isl_type.to_owned());
+        for constraint in constraints {
+            match constraint.constraint() {
+                IslConstraintValue::Type(isl_type) => {
+                    let type_name = self
+                        .fully_qualified_type_ref_name(isl_type, code_gen_context)?
+                        .ok_or(invalid_abstract_data_type_raw_error(format!(
+                            "Could not determine `FullQualifiedTypeReference` for type {:?}",
+                            isl_type
+                        )))?;
+
+                    // by default fields aren't closed
+                    wrapped_scalar_builder.base_type(type_name);
+                }
+                _ => {
+                    return invalid_abstract_data_type_error(
+                        "Could not determine the abstract data type due to conflicting constraints",
+                    );
+                }
+            }
+        }
+
+        Ok(AbstractDataType::WrappedScalar(
+            wrapped_scalar_builder.build()?,
+        ))
+    }
+
+    /// Build scalar data type from constraints
+    fn build_scalar_from_constraints(
+        &mut self,
+        constraints: &[IslConstraint],
+        code_gen_context: &mut CodeGenContext,
+        parent_isl_type: &IslType,
+    ) -> CodeGenResult<AbstractDataType> {
+        let mut scalar_builder = ScalarBuilder::default();
+        scalar_builder.source(parent_isl_type.to_owned());
+        for constraint in constraints {
+            match constraint.constraint() {
+                IslConstraintValue::Type(isl_type) => {
+                    let type_name = self
+                        .fully_qualified_type_ref_name(isl_type, code_gen_context)?
+                        .ok_or(invalid_abstract_data_type_raw_error(format!(
+                            "Could not determine `FullQualifiedTypeReference` for type {:?}",
+                            isl_type
+                        )))?;
+
+                    // by default fields aren't closed
+                    scalar_builder.base_type(type_name);
+                }
+                _ => {
+                    return invalid_abstract_data_type_error(
+                        "Could not determine the abstract data type due to conflicting constraints",
+                    );
+                }
+            }
+        }
+
+        Ok(AbstractDataType::Scalar(scalar_builder.build()?))
     }
 }
 
@@ -535,6 +613,7 @@ mod isl_to_model_tests {
             &"my_struct".to_string(),
             &isl_type,
             &mut CodeGenContext::new(),
+            false,
         )?;
         let abstract_data_type = data_model_node.code_gen_type.unwrap();
         assert_eq!(
@@ -620,6 +699,7 @@ mod isl_to_model_tests {
             &"my_nested_struct".to_string(),
             &isl_type,
             &mut CodeGenContext::new(),
+            false,
         )?;
         let abstract_data_type = data_model_node.code_gen_type.unwrap();
         assert_eq!(

--- a/src/bin/ion/commands/generate/templates/java/scalar.templ
+++ b/src/bin/ion/commands/generate/templates/java/scalar.templ
@@ -1,69 +1,77 @@
-package {{ namespace }};
-import java.util.ArrayList;
+{% macro scalar(model) %}
+{% set full_namespace = namespace | join(sep=".") %}
+
+package {{ full_namespace }};
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonException;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.IonType;
 import java.io.IOException;
 
-public class {{ target_kind_name }} {
-    private {{ fields[0].value_type }} value;
+{# Verify that the abstract data type is a scalar type and store information for this scalar value #}
+{% set scalar_info = model.code_gen_type["WrappedScalar"] %}
+{% set base_type = scalar_info["base_type"] | fully_qualified_type_name %}
 
-    public {{ target_kind_name }}() {}
+class {{ model.name }} {
+    private {{ base_type }} value;
 
-    public {{ fields[0].value_type }} getValue() {
+    public {{ model.name }}() {}
+
+    public {{ base_type }} getValue() {
         return this.value;
     }
 
-    public void setValue({{ fields[0].value_type }} value) {
+    public void setValue({{ base_type }} value) {
         this.value = value;
         return;
     }
 
     /**
-     * Reads a {{ target_kind_name }} from an {@link IonReader}.
+     * Reads a {{ model.name }} from an {@link IonReader}.
      *
      * This method does not advance the reader at the current level.
      * The caller is responsible for positioning the reader on the value to read.
      */
-    public static {{ target_kind_name }} readFrom(IonReader reader) {
+    public static {{ model.name }} readFrom(IonReader reader) {
         {# Initializes all the fields of this class #}
-        {{ fields[0].value_type }} value =
-        {% if fields[0].value_type == "boolean" %}
+        {{ base_type }} value =
+        {% if base_type == "boolean" %}
             false
-        {% elif fields[0].value_type == "int" or fields[0].value_type == "double" %}
+        {% elif base_type == "int" or base_type == "double" %}
             0
         {% else %}
             null
         {% endif %};
         {# Reads `Value` class with a single field `value` #}
-        value = {% if fields[0].value_type | is_built_in_type %}
-                    {% if fields[0].value_type == "bytes[]" %}
+        value = {% if base_type | is_built_in_type %}
+                    {% if base_type == "bytes[]" %}
                         reader.newBytes();
                     {% else %}
-                        reader.{{ fields[0].value_type | camel }}Value();
+                        reader.{{ base_type | camel }}Value();
                     {% endif %}
                  {% else %}
-                    {{ fields[0].value_type }}.readFrom(reader);
+                    {{ base_type }}.readFrom(reader);
                  {% endif %}
-        {{ target_kind_name }} {{ target_kind_name | camel }} = new {{ target_kind_name }}();
-        {{ target_kind_name | camel }}.value = value;
+        {{ model.name }} {{ model.name | camel }} = new {{ model.name }}();
+        {{ model.name | camel }}.value = value;
 
-        return  {{ target_kind_name | camel }};
+        return  {{ model.name | camel }};
     }
 
     /**
-     * Writes a {{ target_kind_name }} as Ion from an {@link IonWriter}.
+     * Writes a {{ model.name }} as Ion from an {@link IonWriter}.
      *
      * This method does not close the writer after writing is complete.
      * The caller is responsible for closing the stream associated with the writer.
      */
     public void writeTo(IonWriter writer) throws IOException {
         {# Writes `Value` class with a single field `value` as an Ion value #}
-        {% if fields[0].value_type | is_built_in_type == false  %}
+        {% if base_type | is_built_in_type == false  %}
             this.value.writeTo(writer)?;
         {% else %}
-            writer.write{{ fields[0].isl_type_name | upper_camel }}(this.value);
+            writer.write{{ base_type | replace(from="double", to="float") | replace(from="boolean", to="bool") | upper_camel }}(this.value);
         {% endif %}
     }
 }
+{% endmacro %}
+{{ self::scalar(model=model) }}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -239,6 +239,17 @@ mod code_gen_tests {
     & ["private int id;", "private String name;"],
     & ["public String getName() {", "public int getId() {"]
     )]
+    #[case(
+    "Scalar",
+    r#"
+        type::{
+         name: scalar,
+         type: string
+        }
+    "#,
+    & ["private String value;"],
+    & ["public String getValue() {"]
+    )]
     /// Calls ion-cli generate with different schema file. Pass the test if the return value contains the expected properties and accessors.
     fn test_code_generation_in_java(
         #[case] test_name: &str,


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
This PR works on adding new model changes following up on #135. This Pr only contains changes for `Structure` (does not contains changes for model variants `Sequence` and `Scalar`). This PR disables Rust support until the entire functionality for the new model change is supported and uses feature branch `new-model-changes` as target.


### List of changes:
* Generator changes:
  * Adds `build_wrapped_scalar_from_constraints` which is used for constructing named scalar data type as data model.
  * Adds `build_scalar_from_constraints` which is used for constructing nested scalar data type as data model. (Doesn't have a name)
  * Adds `is_nested` flag in `convert_isl_type_def_to_data_model_node` which can be used to either call wrapped sclar or scalar ADT construction.
  * Modified `structure` construction to move the common logic at the beginning of the method.
  
* Model changes:
  * Changes `Scalar` and `WrappedScalar` ADT to represent the underlying scalar type with `base_type` and its name with `name` field.
  * Adds doc comment changes for the same
* Adds templates changes for `java/scalar.templ`  

### Generated code:
The generated code still stays the same only the template changes to use the new model. (Only added scalar files for checking this change, other files remain same)

Generated Java code can be found [here](https://gist.github.com/desaikd/d9d195d68f633e00c219b0e81cb02f09).

### Tests:
- Adds tests for ISL to model conversion.
- Modifies roundtrip code gen tests for `scalar` test cases.
    
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
