### PR TITLE
Adds support for builder API generation in Java

### DIFF
--- a/code-gen-projects/java/code-gen-demo/src/test/java/org/example/CodeGenTest.java
+++ b/code-gen-projects/java/code-gen-demo/src/test/java/org/example/CodeGenTest.java
@@ -22,91 +22,61 @@ class CodeGenTest {
     private static final IonSystem ionSystem = IonSystemBuilder.standard().build();
     private static final IonLoader ionLoader = ionSystem.getLoader();
 
-    @Test void getterAndSetterTestForStructWithFields() {
-         StructWithFields s = new StructWithFields();
+    @Test void builderTestForStructWithFields() {
+         StructWithFields.StructWithFieldsBuilder sb = new StructWithFields.StructWithFieldsBuilder();
+         ArrayList<String> c = new ArrayList<String>();
+         c.add("foo");
+         c.add("bar");
+         c.add("baz");
 
          // set all the fields of `StructWithFields`
-         s.setA("hello");
-         s.setB(12);
-         s.setD(10e2);
+         StructWithFields s = sb.a("hello").b(12).c(c).d(10e2).build();
 
          // getter tests for `StructWithFields`
          assertEquals("hello", s.getA(), "s.getA() should return \"hello\"");
          assertEquals(12, s.getB(), "s.getB() should return `12`");
+         assertEquals(3, s.getC().size(), "s.getC() should return ArrayList fo size 3");
          assertEquals(10e2, s.getD(), "s.getD() should return `10e2`");
-
-         // setter tests for `StructWithFields`
-         s.setA("hi");
-         assertEquals("hi", s.getA(), "s.getA() should return \"hi\"");
-         s.setB(6);
-         assertEquals(6, s.getB(), "s.getB() should return `6`");
-         s.setD(11e3);
-         assertEquals(11e3 ,s.getD(), "s.getD() should return `11e3`");
     }
 
-    @Test void getterAndSetterTestForNestedStruct() {
+    @Test void builderTestForNestedStruct() {
          // getter tests for `NestedStruct`
-         NestedStruct n = new NestedStruct();
+         NestedStruct.NestedStructBuilder nb = new NestedStruct.NestedStructBuilder();
          ArrayList<Integer> e = new ArrayList<Integer>();
          e.add(1);
          e.add(2);
          e.add(3);
 
          // set all the fields of `NestedStruct`
-         n.setA("hello");
-         n.setB(12);
-         NestedStruct.NestedType1 n1 = new NestedStruct.NestedType1();
-         n1.setD(false);
-         n1.setE(e);
-         n.setC(n1);
+         NestedStruct.NestedType1.NestedType1Builder nb1 = new NestedStruct.NestedType1.NestedType1Builder();
+         NestedStruct.NestedType1 c = nb1.d(false).e(e).build();
+         NestedStruct n = nb.a("hello").b(12).c(c).build();
 
          // getter tests for `NestedStruct`
          assertEquals("hello", n.getA(), "n.getA() should return \"hello\"");
          assertEquals(12, n.getB(), "n.getB() should return `12`");
          assertEquals(false, n.getC().getD(), "n.getC().getD() should return `false`");
          assertEquals(3, n.getC().getE().size(), "n.getC().getE().size() should return ArrayList fo size 3");
-
-          // setter tests for `NestedStruct`
-          n.setA("hi");
-          assertEquals("hi", n.getA(), "s.getA() should return \"hi\"");
-          n.setB(6);
-          assertEquals(6, n.getB(), "s.getB() should return `6`");
-          n.getC().setD(true);
-          assertEquals(true, n.getC().getD(), "s.getC().getD() should return `true`");
-          n.getC().setE(new ArrayList<Integer>());
-          assertEquals(0, n.getC().getE().size(), "s.getC().getE().size() should return ArrayList fo size 0");
     }
 
-    @Test void getterAndSetterTestForSequence() {
+    @Test void builderTestForSequence() {
+         Sequence.SequenceBuilder sb = new Sequence.SequenceBuilder();
          ArrayList<String> a = new ArrayList<String>();
          a.add("foo");
          a.add("bar");
          a.add("baz");
-         Sequence s = new Sequence();
-
-         // set all the fields of `Sequence`
-         s.setValue(a);
+         Sequence s = sb.value(a).build();
 
          // getter tests for `Sequence`
          assertEquals(3, s.getValue().size(), "s.getValue().size() should return ArrayList fo size 3");
-
-         // setter tests for `Sequence`
-         s.setValue(new ArrayList<String>());
-         assertEquals(true, s.getValue().isEmpty(), "s.getValue().isEmpty() should return `true`");
     }
 
-    @Test void getterAndSetterTestForScalar() {
-         Scalar s = new Scalar();
-
-         // set all the fields of `Scalar`
-         s.setValue("hello");
+    @Test void builderTestForScalar() {
+         Scalar.ScalarBuilder sb = new Scalar.ScalarBuilder();
+         Scalar s = sb.value("hello").build();
 
          // getter tests for `Scalar`
          assertEquals("hello", s.getValue(), "s.getValue() should return \"hello\"");
-
-         // setter tests for `Scalar`
-         s.setValue("hi");
-         assertEquals("hi", s.getValue(), "s.getValue() should return \"hi\"");
     }
 
     @FunctionalInterface

--- a/src/bin/ion/commands/generate/templates/java/class.templ
+++ b/src/bin/ion/commands/generate/templates/java/class.templ
@@ -24,7 +24,7 @@ import java.io.IOException;
            private {{ field_value.0 | fully_qualified_type_name }} {{ field_name | camel }};
     {% endfor %}
 
-    public {{ model.name }}() {}
+    private {{ model.name }}() {}
 
     {% for field_name, field_value in struct_info["fields"] -%}public {{ field_value.0 | fully_qualified_type_name }} get{% filter upper_camel %}{{ field_name }}{% endfilter %}() {
         return this.{{ field_name | camel }};
@@ -39,6 +39,45 @@ import java.io.IOException;
         }
     {% endfor %}
 
+    public static class {{ model.name }}Builder {
+        {% for field_name, field_val in struct_info["fields"] -%}
+            {% set field_value = field_val.0 | fully_qualified_type_name %}
+            private java.util.Optional<{{ field_value | wrapper_class }}> {{ field_name | camel }};
+        {% endfor %}
+
+        {{ model.name }}Builder() {
+            {# Initializes all the fields of this class #}
+            {% for field_name, field_val in struct_info["fields"] -%}
+                {% set field_value = field_val.0 | fully_qualified_type_name %}
+                {% set field_occurrence = field_val.1 %}
+                {# Initialize all the required fields as `java.util.Optional` to verify if the required fields were missing or not #}
+                this.{{ field_name | camel }} = java.util.Optional.empty();
+            {% endfor %}
+        }
+
+        {% for field_name, field_val in struct_info["fields"] %}
+            {% set field_value = field_val.0 %}
+            {% set val = field_value | fully_qualified_type_name %}
+            public {{ model.name }}Builder {{ field_name | camel }}({{ val }} {{ field_name | camel }}) {
+                this.{{ field_name | camel }} = java.util.Optional.of({{ field_name | camel }});
+                return this;
+            }
+        {% endfor %}
+
+        public {{ model.name }} build() {
+            {{ model.name }} {{ model.name | camel }} = new {{ model.name }}();
+            {% for field_name, field_val in struct_info["fields"] -%}
+                {# field_val.1 is the field occurrence #}
+                {% if field_val.1 == "Required" %}
+                if (!{{ field_name | camel }}.isPresent()) {
+                    throw new IonException("Can not find field name: {{ field_name }} for {{ model.name }} while reading Ion data.");
+                }
+                {% endif %}
+                {{ model.name | camel }}.{{ field_name | camel }} = {{ field_name | camel }}.orElse(null);
+            {% endfor %}
+            return {{ model.name | camel }};
+        }
+    }
 
     /**
      * Reads a {{ model.name }} from an {@link IonReader}.
@@ -47,13 +86,8 @@ import java.io.IOException;
      * The caller is responsible for positioning the reader on the value to read.
      */
     public static {{ model.name }} readFrom(IonReader reader) {
-        {# Initializes all the fields of this class #}
-        {% for field_name, field_val in struct_info["fields"] -%}
-            {% set field_value = field_val.0 | fully_qualified_type_name %}
-            {% set field_occurrence = field_val.1 %}
-            {# Initialize all the required fields as `java.util.Optional` to verify if the required fields were missing or not #}
-            java.util.Optional<{{ field_value | wrapper_class }}> {{ field_name | camel }} = java.util.Optional.empty();
-        {% endfor %}
+        {# Initializes the builder for this class #}
+        {{ model.name }}Builder {{ model.name | camel }}Builder = new {{ model.name }}Builder();
 
         {# Reads `Structure` class with multiple fields based on `field.name` #}
         reader.stepIn();
@@ -66,7 +100,7 @@ import java.io.IOException;
                 {% set field_occurrence = field_val.1 %}
                 {% if field_occurrence == "Optional" %} {% set field_value = field_value | primitive_data_type %} {% endif %}
                 case "{{ field_name }}":
-                    {{ field_name | camel }} =  java.util.Optional.of(
+                  {{ model.name | camel }}Builder = {{ model.name | camel }}Builder.{{ field_name | camel }}(
                                                 {% if field_value | is_built_in_type %}
                                                    {% if field_value == "bytes[]" %}
                                                         reader.newBytes()
@@ -86,18 +120,7 @@ import java.io.IOException;
         }
         reader.stepOut();
 
-        {{ model.name }} {{ model.name | camel }} = new {{ model.name }}();
-        {% for field_name, field_val in struct_info["fields"] -%}
-            {# field_val.1 is the field occurrence #}
-            {% if field_val.1 == "Required" %}
-            if (!{{ field_name | camel }}.isPresent()) {
-                throw new IonException("Can not find field name: {{ field_name }} for {{ model.name }} while reading Ion data.");
-            }
-            {% endif %}
-            {{ model.name | camel }}.{{ field_name | camel }} = {{ field_name | camel }}.orElse(null);
-        {% endfor %}
-
-        return  {{ model.name | camel }};
+        return  {{ model.name | camel }}Builder.build();
     }
 
     /**

--- a/src/bin/ion/commands/generate/templates/java/scalar.templ
+++ b/src/bin/ion/commands/generate/templates/java/scalar.templ
@@ -26,6 +26,34 @@ class {{ model.name }} {
         return;
     }
 
+   public static class {{ model.name }}Builder {
+        {{ base_type }} value;
+
+        {{ model.name }}Builder() {
+            {# Initializes value #}
+            this.value =
+            {% if base_type == "boolean" %}
+                false
+            {% elif base_type == "int" or base_type == "double" %}
+                0
+            {% else %}
+                null
+            {% endif %};
+        }
+
+        public {{ model.name }}Builder value({{ base_type }} value) {
+            this.value = value;
+            return this;
+        }
+
+        public {{ model.name }} build() {
+            {{ model.name }} {{ model.name | camel }} = new {{ model.name }}();
+            {{ model.name | camel }}.value = value;
+
+            return  {{ model.name | camel }};
+        }
+   }
+
     /**
      * Reads a {{ model.name }} from an {@link IonReader}.
      *
@@ -33,29 +61,21 @@ class {{ model.name }} {
      * The caller is responsible for positioning the reader on the value to read.
      */
     public static {{ model.name }} readFrom(IonReader reader) {
-        {# Initializes all the fields of this class #}
-        {{ base_type }} value =
-        {% if base_type == "boolean" %}
-            false
-        {% elif base_type == "int" or base_type == "double" %}
-            0
-        {% else %}
-            null
-        {% endif %};
+        {# Initializes the builder for this class #}
+        {{ model.name }}Builder {{ model.name | camel }}Builder = new {{ model.name }}Builder();
+
         {# Reads `Value` class with a single field `value` #}
-        value = {% if base_type | is_built_in_type %}
+        {{ model.name | camel }}Builder = {{ model.name | camel }}Builder.value({% if base_type | is_built_in_type %}
                     {% if base_type == "bytes[]" %}
                         reader.newBytes();
                     {% else %}
-                        reader.{{ base_type | camel }}Value();
+                        reader.{{ base_type | camel }}Value()
                     {% endif %}
                  {% else %}
-                    {{ base_type }}.readFrom(reader);
-                 {% endif %}
-        {{ model.name }} {{ model.name | camel }} = new {{ model.name }}();
-        {{ model.name | camel }}.value = value;
+                    {{ base_type }}.readFrom(reader)
+                 {% endif %});
 
-        return  {{ model.name | camel }};
+        return  {{ model.name | camel }}Builder.build();
     }
 
     /**

--- a/src/bin/ion/commands/generate/templates/java/sequence.templ
+++ b/src/bin/ion/commands/generate/templates/java/sequence.templ
@@ -17,7 +17,7 @@ import java.io.IOException;
 class {{ model.name }} {
     private java.util.ArrayList<{{ sequence_info["element_type"] | fully_qualified_type_name }}> value;
 
-    public {{ model.name }}() {}
+    private {{ model.name }}() {}
 
     public java.util.ArrayList<{{ sequence_info["element_type"] | fully_qualified_type_name }}> getValue() {
         return this.value;
@@ -27,6 +27,26 @@ class {{ model.name }} {
         this.value = value;
         return;
     }
+
+     public static class {{ model.name }}Builder {
+        java.util.ArrayList<{{ sequence_info["element_type"] | fully_qualified_type_name }}> value;
+
+        {{ model.name }}Builder() {
+            this.value = null;
+        }
+
+        public {{ model.name }}Builder value(java.util.ArrayList<{{ sequence_info["element_type"] | fully_qualified_type_name }}> value) {
+            this.value = value;
+            return this;
+        }
+
+        public {{ model.name }} build() {
+            {{ model.name }} {{ model.name | camel }} = new {{ model.name }}();
+            {{ model.name | camel }}.value = value;
+
+            return  {{ model.name | camel }};
+        }
+     }
 
     /**
      * Reads a {{ model.name }} from an {@link IonReader}.
@@ -54,10 +74,10 @@ class {{ model.name }} {
             {% endif %}
         }
         reader.stepOut();
-        {{ model.name }} {{ model.name | camel }} = new {{ model.name }}();
-        {{ model.name | camel }}.value = value;
+        {# Initializes the builder for this class #}
+        {{ model.name }}Builder {{ model.name | camel }}Builder = new {{ model.name }}Builder();
 
-        return  {{ model.name | camel }};
+        return  {{ model.name | camel }}Builder.value(value).build();
     }
 
     /**


### PR DESCRIPTION
### Issue #97

### Description of changes:
This PR adds support for builder API generation in Java.

### Generated code in Java:

Generated code adds builder API support which can be found [here](https://gist.github.com/desaikd/9bc492a58e2e53e301814a4e058f3e1d).

### List of changes:
- [Adds Java template changes for builder API generation](https://github.com/amazon-ion/ion-cli/commit/6def28e1186c38fabf74797c3e701904125ce14e)
  * Adds nested builder class
  * `build` mehtod verifies required/optional fields
  * `readFrom` usess new builder to create an instance of the class
-  [Modifies Java tests for builder API](https://github.com/amazon-ion/ion-cli/commit/665bb7269f302bc240e657abcecf89de289e618b)
  
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
