### PR TITLE
Improve help messages

### DIFF
--- a/src/bin/ion/commands/complaint.rs
+++ b/src/bin/ion/commands/complaint.rs
@@ -1,0 +1,34 @@
+use crate::commands::IonCliCommand;
+use clap::{ArgMatches, Command};
+
+pub struct SucksCommand;
+
+impl IonCliCommand for SucksCommand {
+    fn is_stable(&self) -> bool {
+        true
+    }
+
+    fn name(&self) -> &'static str {
+        "sucks"
+    }
+
+    fn about(&self) -> &'static str {
+        ""
+    }
+
+    fn configure_args(&self, command: Command) -> Command {
+        command.hide(true)
+    }
+
+    fn run(&self, command_path: &mut Vec<String>, args: &ArgMatches) -> anyhow::Result<()> {
+        println!(
+            "
+        We're very sorry to hear that!
+
+        Rather than complaining into the void, why not file an issue?
+        https://github.com/amazon-ion/ion-docs/issues/new/choose
+        "
+        );
+        Ok(())
+    }
+}

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -11,6 +11,7 @@ use termcolor::{ColorChoice, StandardStream, StandardStreamLock};
 
 pub mod cat;
 mod command_namespace;
+pub mod complaint;
 pub mod from;
 pub mod generate;
 pub mod hash;
@@ -53,6 +54,11 @@ pub trait IonCliCommand {
     /// A brief message describing this command's functionality.
     fn about(&self) -> &'static str;
 
+    /// A long message describing this command's functionality.
+    fn long_about(&self) -> Option<&'static str> {
+        None
+    }
+
     /// Initializes a [`ClapCommand`] representing this command and its subcommands (if any).
     ///
     /// Commands wishing to customize their `ClapCommand`'s arguments should override
@@ -77,6 +83,10 @@ pub trait IonCliCommand {
                     .display_order(usize::MAX)
                     .hide(true),
             );
+
+        if let Some(long_about) = self.long_about() {
+            base_command = base_command.long_about(long_about)
+        }
 
         if !self.is_stable() {
             let about = base_command.get_about().map(|x| x.to_string());

--- a/src/bin/ion/commands/stats.rs
+++ b/src/bin/ion/commands/stats.rs
@@ -22,14 +22,18 @@ impl IonCliCommand for StatsCommand {
     }
 
     fn about(&self) -> &'static str {
-        "Print the analysis report of the input data stream, including the total number of top-level values, their minimum, maximum, and mean sizes,\n\
-        and plot the size distribution of the input stream. The report should also include the number of symbol tables in the input stream,\n\
-        the total number of different symbols that occurred in the input stream, and the maximum depth of the input data stream.\n\
-        Currently, this subcommand only supports data analysis on binary Ion data."
+        "Print statistics about an Ion stream"
     }
 
     fn configure_args(&self, command: Command) -> Command {
-        command.with_input()
+        command
+            .long_about("Print the analysis report of the input data stream, including the total number of\n\
+        top-level values, their minimum, maximum, and mean sizes, and plot the size distribution of\n\
+        the input stream. The report should also include the number of symbol tables in the input\n\
+        stream, the total number of different symbols that occurred in the input stream, and the\n\
+        maximum depth of the input data stream. Currently, this subcommand only supports data\n\
+        analysis on binary Ion data.")
+            .with_input()
     }
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
         CommandIo::new(args).for_each_input(|_output, input| {

--- a/src/bin/ion/main.rs
+++ b/src/bin/ion/main.rs
@@ -5,12 +5,8 @@ mod input;
 mod output;
 mod transcribe;
 
-use anyhow::Result;
-use commands::{IonCliCommand, IonCliNamespace};
-use ion_rs::IonError;
-use std::io::ErrorKind;
-
 use crate::commands::cat::CatCommand;
+use crate::commands::complaint::SucksCommand;
 use crate::commands::from::FromNamespace;
 use crate::commands::generate::GenerateCommand;
 use crate::commands::hash::HashCommand;
@@ -21,10 +17,16 @@ use crate::commands::schema::SchemaNamespace;
 use crate::commands::stats::StatsCommand;
 use crate::commands::symtab::SymtabNamespace;
 use crate::commands::to::ToNamespace;
+use anyhow::Result;
+use commands::{IonCliCommand, IonCliNamespace};
+use ion_rs::IonError;
+use std::io::ErrorKind;
 
 fn main() -> Result<()> {
     let root_command = RootCommand;
-    let args = root_command.clap_command().get_matches();
+    let args = root_command.clap_command()
+        .after_help("Having a problem with Ion CLI?\nOpen an issue at https://github.com/amazon-ion/ion-cli/issues/new/choose")
+        .get_matches();
     let mut command_path: Vec<String> = vec![IonCliNamespace::name(&root_command).to_owned()];
 
     if let Err(e) = root_command.run(&mut command_path, &args) {
@@ -65,6 +67,7 @@ impl IonCliNamespace for RootCommand {
             Box::new(SymtabNamespace),
             Box::new(ToNamespace),
             Box::new(StatsCommand),
+            Box::new(SucksCommand),
         ]
     }
 }


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

* Commands now support a "regular" `about`, and a `long_about`. This allows us to put the shorter one into the listing of subcommands and the longer one can go in the more detailed help.
* Reformat the help messaging for `ion stats` so that it wraps at a similar line length as the other commands.
* Adds a comment to the end of the top-level help directing users to open an issue in `ion-cli` if they are experiencing a problem with the CLI.
* Adds a little surprise for when you are upset with Ion. 

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
