### PR TITLE
Adds 'report' output for ion schema validate

### DIFF
--- a/src/bin/ion/ansi_codes.rs
+++ b/src/bin/ion/ansi_codes.rs
@@ -1,0 +1,14 @@
+//! Ansi Codes are a convenient way to add styling to text in a terminal.
+//! There are libraries that can accomplish the same thing, but when you want to have a large block
+//! of static text, sometimes it's simpler to just use `format!()` and include named substitutions
+//! (like `{BOLD}`) to turn styling on and off.
+
+// TODO: Add more constants as needed.
+
+pub(crate) const NO_STYLE: &str = "\x1B[0m";
+pub(crate) const BOLD: &str = "\x1B[1m";
+pub(crate) const ITALIC: &str = "\x1B[3m";
+pub(crate) const UNDERLINE: &str = "\x1B[4m";
+
+pub(crate) const RED: &str = "\x1B[0;31m";
+pub(crate) const GREEN: &str = "\x1B[0;32m";

--- a/src/bin/ion/commands/complaint.rs
+++ b/src/bin/ion/commands/complaint.rs
@@ -20,7 +20,7 @@ impl IonCliCommand for SucksCommand {
         command.hide(true)
     }
 
-    fn run(&self, command_path: &mut Vec<String>, args: &ArgMatches) -> anyhow::Result<()> {
+    fn run(&self, _command_path: &mut Vec<String>, _args: &ArgMatches) -> anyhow::Result<()> {
         println!(
             "
         We're very sorry to hear that!

--- a/src/bin/ion/main.rs
+++ b/src/bin/ion/main.rs
@@ -1,3 +1,4 @@
+mod ansi_codes;
 mod auto_decompress;
 mod commands;
 mod file_writer;


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

* Adds a module with ansi code constants that can be imported and used in a `format!()` string. See `validate.rs` for example usage.
* Adds more help documentation to the `validate` command.
* Fixes a clippy warning in `complaint.rs`.
* Adds a new "report" output format for the validate command. "Report" is a rather vague name, so if you have a better idea, please share it with me.

Example usage and output (but `ok` is green and `FAILED` is red, just like the `cargo test` report).
```
❯ cargo run -- schema -X validate -R 'document' **/*.ion

code-gen-projects/input/good/scalar/empty_value.ion ... ok
code-gen-projects/input/good/scalar/valid_value.ion ... ok
code-gen-projects/input/good/sequence/empty_sequence.ion ... FAILED
code-gen-projects/input/good/sequence/valid_elements.ion ... ok
code-gen-projects/input/good/struct_with_fields/empty_values.ion ... FAILED
code-gen-projects/input/good/struct_with_fields/valid_fields.ion ... ok
code-gen-projects/input/good/struct_with_fields/valid_unordered_fields.ion ... ok
```

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
