### PR TITLE
Update ion-schema dependency; bump version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "ion-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -968,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "ion-schema"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d1b8c63d60bed2413c751d9dc6c8ff49b34d0b9b7357f1bcfc31e5e832667c"
+checksum = "fa5961f23d04dc16ed65e67762527344ac02c808c6d1e7ea5af4f2fc5929c434"
 dependencies = [
  "half",
  "ion-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ion-cli"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["The Ion Team <ion-team@amazon.com>"]
 edition = "2021"
 description = "Command line tool for working with the Ion data format."
@@ -24,7 +24,7 @@ infer = "0.15.0"
 # See https://github.com/amazon-ion/ion-cli/issues/155
 ion-rs = { version = "=1.0.0-rc.8", features = ["experimental", "experimental-ion-hash"] }
 tempfile = "3.2.0"
-ion-schema = "0.14.0"
+ion-schema = "0.14.1"
 lowcharts = "0.5.8"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = { version = "1.0.81", features = ["arbitrary_precision", "preserve_order"] }


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

* Updates to use the latest version of `ion-schema`.
* Bumps version so we can release all of the latest and greatest `ion schema validate` improvements.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
