### PR TITLE
Adds namespace fix for nested sequence and adds support for nested types in Sequence and Scalar ADT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,6 +959,7 @@ dependencies = [
  "infer",
  "ion-rs 1.0.0-rc.6",
  "ion-schema",
+ "itertools 0.13.0",
  "lowcharts",
  "matches",
  "pager",
@@ -1050,6 +1051,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1388,7 +1398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
- "itertools",
+ "itertools 0.10.5",
  "predicates-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ thiserror = "1.0.50"
 zstd = "0.13.0"
 termcolor = "1.4.1"
 derive_builder = "0.20.0"
+itertools = "0.13.0"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 pager = "0.16.1"

--- a/code-gen-projects/input/bad/sequence_with_enum_element/invalid_value.ion
+++ b/code-gen-projects/input/bad/sequence_with_enum_element/invalid_value.ion
@@ -1,1 +1,1 @@
-[failed] // expected values are either pass or fail, found failed.
+[foobar] // expected values are either foo , bar or baz, found foobar.

--- a/code-gen-projects/input/bad/sequence_with_enum_element/invalid_value.ion
+++ b/code-gen-projects/input/bad/sequence_with_enum_element/invalid_value.ion
@@ -1,0 +1,1 @@
+[failed] // expected values are either pass or fail, found failed.

--- a/code-gen-projects/input/good/sequence_with_enum_element/valid_value.ion
+++ b/code-gen-projects/input/good/sequence_with_enum_element/valid_value.ion
@@ -1,0 +1,1 @@
+[pass, fail]

--- a/code-gen-projects/input/good/sequence_with_enum_element/valid_value.ion
+++ b/code-gen-projects/input/good/sequence_with_enum_element/valid_value.ion
@@ -1,1 +1,1 @@
-[pass, fail]
+[foo, bar, baz]

--- a/code-gen-projects/java/code-gen-demo/src/test/java/org/example/CodeGenTest.java
+++ b/code-gen-projects/java/code-gen-demo/src/test/java/org/example/CodeGenTest.java
@@ -137,6 +137,12 @@ class CodeGenTest {
         runRoundtripBadTest("/bad/enum_type", EnumType::readFrom);
     }
 
+
+    @Test
+    void roundtripBadTestForSequenceWithEnumElement() throws IOException {
+        runRoundtripBadTest("/bad/sequence_with_enum_element", SequenceWithEnumElement::readFrom);
+    }
+
     private <T> void runRoundtripBadTest(String path, ReaderFunction<T> readerFunction) throws IOException {
         File dir = new File(System.getenv("ION_INPUT") + path);
         String[] fileNames = dir.list();
@@ -180,6 +186,11 @@ class CodeGenTest {
     @Test
     void roundtripGoodTestForEnumType() throws IOException {
         runRoundtripGoodTest("/good/enum_type", EnumType::readFrom, (item, writer) -> item.writeTo(writer));
+    }
+
+    @Test
+    void roundtripGoodTestForSequenceWithEnumElement() throws IOException {
+        runRoundtripGoodTest("/good/sequence_with_enum_element", SequenceWithEnumElement::readFrom, (item, writer) -> item.writeTo(writer));
     }
 
     private <T> void runRoundtripGoodTest(String path, ReaderFunction<T> readerFunction, WriterFunction<T> writerFunction) throws IOException {

--- a/code-gen-projects/schema/sequence_with_enum_element.isl
+++ b/code-gen-projects/schema/sequence_with_enum_element.isl
@@ -1,0 +1,5 @@
+type::{
+    name: sequence_with_enum_element,
+    type: list,
+    element: { valid_values: [pass, fail] }
+}

--- a/code-gen-projects/schema/sequence_with_enum_element.isl
+++ b/code-gen-projects/schema/sequence_with_enum_element.isl
@@ -1,5 +1,5 @@
 type::{
     name: sequence_with_enum_element,
     type: list,
-    element: { valid_values: [pass, fail] }
+    element: { valid_values: [foo, bar, baz] }
 }

--- a/src/bin/ion/commands/generate/generator.rs
+++ b/src/bin/ion/commands/generate/generator.rs
@@ -849,6 +849,12 @@ impl<'a, L: Language + 'static> CodeGenerator<'a, L> {
         for constraint in constraints {
             match constraint.constraint() {
                 IslConstraintValue::Type(isl_type) => {
+                    // Nested/Anonymous types are not allowed within wrapped scalar models
+                    if matches!(isl_type, IslTypeRef::Anonymous(_, _)) {
+                        return invalid_abstract_data_type_error(
+                            "Nested types are not supported within wrapped scalar types(i.e. within top level ISL type definition's `type` constraint)",
+                        );
+                    }
                     let type_name = self.handle_duplicate_constraint(
                         found_base_type,
                         "type",

--- a/src/bin/ion/commands/generate/generator.rs
+++ b/src/bin/ion/commands/generate/generator.rs
@@ -413,7 +413,7 @@ impl<'a, L: Language + 'static> CodeGenerator<'a, L> {
             isl_type_name,
             &mut context,
             &data_model_node,
-            &data_model_node
+            data_model_node
                 .fully_qualified_type_name()
                 .unwrap()
                 .as_slice(),

--- a/src/bin/ion/commands/generate/mod.rs
+++ b/src/bin/ion/commands/generate/mod.rs
@@ -7,6 +7,7 @@ mod utils;
 mod model;
 
 use crate::commands::generate::generator::CodeGenerator;
+use crate::commands::generate::model::NamespaceNode;
 use crate::commands::generate::utils::{JavaLanguage, RustLanguage};
 use crate::commands::IonCliCommand;
 use anyhow::{bail, Result};
@@ -124,7 +125,7 @@ impl IonCliCommand for GenerateCommand {
                 match language {
                     "java" => {
                         Self::print_java_code_gen_warnings();
-                        CodeGenerator::<JavaLanguage>::new(output, namespace.unwrap().split('.').map(|s| s.to_string()).collect())
+                        CodeGenerator::<JavaLanguage>::new(output, namespace.unwrap().split('.').map(|s| NamespaceNode::Package(s.to_string())).collect())
                             .generate_code_for_authorities(&authorities, &mut schema_system)?
                     },
                     "rust" => {
@@ -143,7 +144,7 @@ impl IonCliCommand for GenerateCommand {
                 match language {
                     "java" =>  {
                         Self::print_java_code_gen_warnings();
-                        CodeGenerator::<JavaLanguage>::new(output, namespace.unwrap().split('.').map(|s| s.to_string()).collect()).generate_code_for_schema(&mut schema_system, schema_id)?
+                        CodeGenerator::<JavaLanguage>::new(output, namespace.unwrap().split('.').map(|s| NamespaceNode::Package(s.to_string())).collect()).generate_code_for_schema(&mut schema_system, schema_id)?
                     },
                     "rust" => {
                         Self::print_rust_code_gen_warnings();

--- a/src/bin/ion/commands/generate/model.rs
+++ b/src/bin/ion/commands/generate/model.rs
@@ -79,6 +79,12 @@ impl DataModelNode {
             .as_ref()
             .map(|t| t.fully_qualified_type_ref::<L>())
     }
+
+    pub fn fully_qualified_type_name(&self) -> Option<FullyQualifiedTypeName> {
+        self.code_gen_type
+            .as_ref()
+            .and_then(|t| t.fully_qualified_type_name())
+    }
 }
 
 /// Represents a fully qualified type name for a type definition
@@ -261,6 +267,18 @@ impl AbstractDataType {
             }
             AbstractDataType::Structure(structure) => structure.name.to_owned().into(),
             AbstractDataType::Enum(enum_type) => enum_type.name.to_owned().into(),
+        }
+    }
+
+    pub fn fully_qualified_type_name(&self) -> Option<FullyQualifiedTypeName> {
+        // nested types would return None
+        match self {
+            AbstractDataType::WrappedScalar(w) => Some(w.fully_qualified_type_name().to_owned()),
+            AbstractDataType::Scalar(_) => None,
+            AbstractDataType::Sequence(_) => None,
+            AbstractDataType::WrappedSequence(seq) => Some(seq.name.to_owned()),
+            AbstractDataType::Structure(structure) => Some(structure.name.to_owned()),
+            AbstractDataType::Enum(enum_type) => Some(enum_type.name.to_owned()),
         }
     }
 }

--- a/src/bin/ion/commands/generate/model.rs
+++ b/src/bin/ion/commands/generate/model.rs
@@ -76,7 +76,7 @@ impl DataModelNode {
     pub fn fully_qualified_type_ref<L: Language>(&mut self) -> Option<FullyQualifiedTypeReference> {
         self.code_gen_type
             .as_ref()
-            .and_then(|t| t.fully_qualified_type_ref::<L>())
+            .map(|t| t.fully_qualified_type_ref::<L>())
     }
 }
 
@@ -211,20 +211,18 @@ impl AbstractDataType {
         }
     }
 
-    pub fn fully_qualified_type_ref<L: Language>(&self) -> Option<FullyQualifiedTypeReference> {
+    pub fn fully_qualified_type_ref<L: Language>(&self) -> FullyQualifiedTypeReference {
         match self {
-            AbstractDataType::WrappedScalar(w) => {
-                Some(w.fully_qualified_type_name().to_owned().into())
-            }
-            AbstractDataType::Scalar(s) => Some(s.base_type.to_owned()),
+            AbstractDataType::WrappedScalar(w) => w.fully_qualified_type_name().to_owned().into(),
+            AbstractDataType::Scalar(s) => s.base_type.to_owned(),
             AbstractDataType::Sequence(seq) => {
-                Some(L::target_type_as_sequence(seq.element_type.to_owned()))
+                L::target_type_as_sequence(seq.element_type.to_owned())
             }
             AbstractDataType::WrappedSequence(seq) => {
-                Some(L::target_type_as_sequence(seq.element_type.to_owned()))
+                L::target_type_as_sequence(seq.element_type.to_owned())
             }
-            AbstractDataType::Structure(structure) => Some(structure.name.to_owned().into()),
-            AbstractDataType::Enum(enum_type) => Some(enum_type.name.to_owned().into()),
+            AbstractDataType::Structure(structure) => structure.name.to_owned().into(),
+            AbstractDataType::Enum(enum_type) => enum_type.name.to_owned().into(),
         }
     }
 }

--- a/src/bin/ion/commands/generate/templates/java/class.templ
+++ b/src/bin/ion/commands/generate/templates/java/class.templ
@@ -5,7 +5,7 @@
 {% macro class(model, is_nested) %}
 
 {% if is_nested == false %}
-{% set full_namespace = namespace | join(sep=".") %}
+{% set full_namespace = namespace | map(attribute="Package") | join(sep=".") %}
 
 package {{ full_namespace }};
 import com.amazon.ion.IonReader;

--- a/src/bin/ion/commands/generate/templates/java/class.templ
+++ b/src/bin/ion/commands/generate/templates/java/class.templ
@@ -147,8 +147,7 @@ import java.io.IOException;
     }
 
     {% for inline_type in model.nested_types -%}
-        {% set is_nested = true %}
-        {{ macros::nested_type(model=inline_type, is_nested=is_nested) }}
+        {{ macros::nested_type(model=inline_type, is_nested=true) }}
     {% endfor -%}
 }
 {% endmacro model %}

--- a/src/bin/ion/commands/generate/templates/java/enum.templ
+++ b/src/bin/ion/commands/generate/templates/java/enum.templ
@@ -1,4 +1,4 @@
-{% set full_namespace = namespace | join(sep=".") %}
+{% set full_namespace = namespace | map(attribute="Package") | join(sep=".") %}
 {% if is_nested == false %}
 package {{ full_namespace }};
 import com.amazon.ion.IonReader;

--- a/src/bin/ion/commands/generate/templates/java/scalar.templ
+++ b/src/bin/ion/commands/generate/templates/java/scalar.templ
@@ -76,8 +76,7 @@ class {{ model.name }} {
     }
 
     {% for inline_type in model.nested_types -%}
-        {% set is_nested = true %}
-        {{ macros::nested_type(model=inline_type, is_nested=is_nested) }}
+        {{ macros::nested_type(model=inline_type, is_nested=true) }}
     {% endfor -%}
 }
 {% endmacro %}

--- a/src/bin/ion/commands/generate/templates/java/scalar.templ
+++ b/src/bin/ion/commands/generate/templates/java/scalar.templ
@@ -1,7 +1,7 @@
 {% import "nested_type.templ"  as macros %}
 
 {% macro scalar(model) %}
-{% set full_namespace = namespace | join(sep=".") %}
+{% set full_namespace = namespace | map(attribute="Package") | join(sep=".") %}
 
 package {{ full_namespace }};
 import com.amazon.ion.IonReader;

--- a/src/bin/ion/commands/generate/templates/java/scalar.templ
+++ b/src/bin/ion/commands/generate/templates/java/scalar.templ
@@ -74,10 +74,6 @@ class {{ model.name }} {
             writer.write{{ base_type | replace(from="double", to="float") | replace(from="boolean", to="bool") | upper_camel }}(this.value);
         {% endif %}
     }
-
-    {% for inline_type in model.nested_types -%}
-        {{ macros::nested_type(model=inline_type, is_nested=true) }}
-    {% endfor -%}
 }
 {% endmacro %}
 {{ self::scalar(model=model) }}

--- a/src/bin/ion/commands/generate/templates/java/scalar.templ
+++ b/src/bin/ion/commands/generate/templates/java/scalar.templ
@@ -1,3 +1,5 @@
+{% import "nested_type.templ"  as macros %}
+
 {% macro scalar(model) %}
 {% set full_namespace = namespace | join(sep=".") %}
 
@@ -72,6 +74,11 @@ class {{ model.name }} {
             writer.write{{ base_type | replace(from="double", to="float") | replace(from="boolean", to="bool") | upper_camel }}(this.value);
         {% endif %}
     }
+
+    {% for inline_type in model.nested_types -%}
+        {% set is_nested = true %}
+        {{ macros::nested_type(model=inline_type, is_nested=is_nested) }}
+    {% endfor -%}
 }
 {% endmacro %}
 {{ self::scalar(model=model) }}

--- a/src/bin/ion/commands/generate/templates/java/sequence.templ
+++ b/src/bin/ion/commands/generate/templates/java/sequence.templ
@@ -3,7 +3,7 @@
 {% macro sequence(model) %}
 
 {% if is_nested == false %}
-{% set full_namespace = namespace | join(sep=".") %}
+{% set full_namespace = namespace | map(attribute="Package") | join(sep=".") %}
 
 package {{ full_namespace }};
 import com.amazon.ion.IonReader;

--- a/src/bin/ion/commands/generate/templates/java/sequence.templ
+++ b/src/bin/ion/commands/generate/templates/java/sequence.templ
@@ -82,8 +82,7 @@ class {{ model.name }} {
     }
 
     {% for inline_type in model.nested_types -%}
-        {% set is_nested = true %}
-        {{ macros::nested_type(model=inline_type, is_nested=is_nested) }}
+        {{ macros::nested_type(model=inline_type, is_nested=true) }}
     {% endfor -%}
 }
 {% endmacro %}

--- a/src/bin/ion/commands/generate/templates/java/sequence.templ
+++ b/src/bin/ion/commands/generate/templates/java/sequence.templ
@@ -1,3 +1,5 @@
+{% import "nested_type.templ"  as macros %}
+
 {% macro sequence(model) %}
 
 {% if is_nested == false %}
@@ -78,6 +80,11 @@ class {{ model.name }} {
         }
         writer.stepOut();
     }
+
+    {% for inline_type in model.nested_types -%}
+        {% set is_nested = true %}
+        {{ macros::nested_type(model=inline_type, is_nested=is_nested) }}
+    {% endfor -%}
 }
 {% endmacro %}
 {{ self::sequence(model=model) }}

--- a/src/bin/ion/commands/generate/templates/java/util_macros.templ
+++ b/src/bin/ion/commands/generate/templates/java/util_macros.templ
@@ -12,7 +12,7 @@
         while (reader.hasNext()) {
             reader.next();
             {% if field_value_model.code_gen_type["Sequence"].element_type | fully_qualified_type_name | is_built_in_type  == false %}
-                {{ field_name | camel }}List.add({{ field_value_model.code_gen_type["Sequence"].element_type }}.readFrom(reader));
+                {{ field_name | camel }}List.add({{ field_value_model.code_gen_type["Sequence"].element_type | fully_qualified_type_name }}.readFrom(reader));
             {% elif field_value_model.code_gen_type["Sequence"].element_type == "bytes[]" %}
                 {{ field_name | camel }}List.add(reader.newBytes());
             {% else %}

--- a/src/bin/ion/commands/generate/templates/rust/scalar.templ
+++ b/src/bin/ion/commands/generate/templates/rust/scalar.templ
@@ -45,8 +45,4 @@ pub mod  {{ model.name | snake }} {
             Ok(())
         }
     }
-
-    {% for inline_type in model.nested_types -%}
-            {{ macros::nested_type(model=inline_type, is_nested=true) }}
-    {% endfor -%}
 }

--- a/src/bin/ion/commands/generate/templates/rust/scalar.templ
+++ b/src/bin/ion/commands/generate/templates/rust/scalar.templ
@@ -1,3 +1,5 @@
+{% import "nested_type.templ"  as macros %}
+
 {# Verify that the abstract data type is a scalar type and store information for this scalar value #}
 {% set scalar_info = model.code_gen_type["WrappedScalar"] %}
 {% set base_type = scalar_info["base_type"] | fully_qualified_type_name %}
@@ -43,4 +45,9 @@ pub mod  {{ model.name | snake }} {
             Ok(())
         }
     }
+
+    {% for inline_type in model.nested_types -%}
+            {% set is_nested = true %}
+            {{ macros::nested_type(model=inline_type, is_nested=is_nested) }}
+    {% endfor -%}
 }

--- a/src/bin/ion/commands/generate/templates/rust/scalar.templ
+++ b/src/bin/ion/commands/generate/templates/rust/scalar.templ
@@ -47,7 +47,6 @@ pub mod  {{ model.name | snake }} {
     }
 
     {% for inline_type in model.nested_types -%}
-            {% set is_nested = true %}
-            {{ macros::nested_type(model=inline_type, is_nested=is_nested) }}
+            {{ macros::nested_type(model=inline_type, is_nested=true) }}
     {% endfor -%}
 }

--- a/src/bin/ion/commands/generate/templates/rust/sequence.templ
+++ b/src/bin/ion/commands/generate/templates/rust/sequence.templ
@@ -1,4 +1,7 @@
+{% import "nested_type.templ"  as macros %}
+
 {% set sequence_info = model.code_gen_type["WrappedSequence"] %}
+
 
 use {{ model.name | snake }}::{{ model.name }};
 
@@ -39,7 +42,7 @@ pub mod  {{ model.name | snake }} {
 
                  while reader.next()? != StreamItem::Nothing {
                     {% if sequence_info["element_type"] | fully_qualified_type_name | is_built_in_type == false %}
-                        values.push({{ sequence_info["element_type"] }}::read_from(reader)?);
+                        values.push({{ sequence_info["element_type"] | fully_qualified_type_name }}::read_from(reader)?);
                     {% else %}
                         values.push(reader.read_{% if field.source is defined and field.source == "symbol" %}symbol()?.text().unwrap(){% else %}{{ sequence_info["element_type"] | fully_qualified_type_name | lower | replace(from="string", to ="str") }}()?{% endif %}{% if sequence_info["element_type"] | fully_qualified_type_name | lower== "string" %} .to_string() {% endif %});
                     {% endif %}
@@ -63,4 +66,10 @@ pub mod  {{ model.name | snake }} {
             Ok(())
         }
     }
+
+
+    {% for inline_type in model.nested_types -%}
+            {% set is_nested = true %}
+            {{ macros::nested_type(model=inline_type, is_nested=is_nested) }}
+    {% endfor -%}
 }

--- a/src/bin/ion/commands/generate/templates/rust/sequence.templ
+++ b/src/bin/ion/commands/generate/templates/rust/sequence.templ
@@ -69,7 +69,6 @@ pub mod  {{ model.name | snake }} {
 
 
     {% for inline_type in model.nested_types -%}
-            {% set is_nested = true %}
-            {{ macros::nested_type(model=inline_type, is_nested=is_nested) }}
+            {{ macros::nested_type(model=inline_type, is_nested=true) }}
     {% endfor -%}
 }

--- a/src/bin/ion/commands/generate/templates/rust/struct.templ
+++ b/src/bin/ion/commands/generate/templates/rust/struct.templ
@@ -87,8 +87,7 @@ pub mod  {{ model.name | snake }} {
     }
 
     {% for inline_type in model.nested_types -%}
-            {% set is_nested = true %}
-            {{ macros::nested_type(model=inline_type, is_nested=is_nested) }}
+            {{ macros::nested_type(model=inline_type, is_nested=true) }}
     {% endfor -%}
 }
 {% endmacro struct %}

--- a/src/bin/ion/commands/generate/utils.rs
+++ b/src/bin/ion/commands/generate/utils.rs
@@ -1,8 +1,9 @@
 use crate::commands::generate::model::{
-    AbstractDataType, DataModelNode, FullyQualifiedTypeReference,
+    AbstractDataType, DataModelNode, FullyQualifiedTypeReference, NamespaceNode,
 };
 use crate::commands::generate::result::{invalid_abstract_data_type_error, CodeGenError};
 use convert_case::{Case, Casing};
+use itertools::Itertools;
 use std::fmt::{Display, Formatter};
 
 pub trait Language {
@@ -69,10 +70,14 @@ pub trait Language {
     ///         ```
     ///     To add `NestedType` into the namespace path, `is_nested_type` helps remove any prior types form the path and add this current type.
     ///     i.e. given namespace path as `foo::Foo`, it will first remove `Foo` and then add the current type as `foo::nested_type::NestedType`.
-    fn add_type_to_namespace(is_nested_type: bool, type_name: &str, namespace: &mut Vec<String>);
+    fn add_type_to_namespace(
+        is_nested_type: bool,
+        type_name: &str,
+        namespace: &mut Vec<NamespaceNode>,
+    );
 
     /// Resets the namespace when code generation is complete for a single ISL type
-    fn reset_namespace(namespace: &mut Vec<String>);
+    fn reset_namespace(namespace: &mut Vec<NamespaceNode>);
 
     /// Returns the `FullyQualifiedReference` that represents the target type as optional in the given programming language
     /// e.g. In Java, it will return "java.util.Optional<T>"
@@ -121,20 +126,20 @@ impl Language for JavaLanguage {
         ) {
             Some(wrapper_name) => FullyQualifiedTypeReference {
                 type_name: vec![
-                    "java".to_string(),
-                    "util".to_string(),
-                    "ArrayList".to_string(),
+                    NamespaceNode::Package("java".to_string()),
+                    NamespaceNode::Package("util".to_string()),
+                    NamespaceNode::Type("ArrayList".to_string()),
                 ],
                 parameters: vec![FullyQualifiedTypeReference {
-                    type_name: vec![wrapper_name],
+                    type_name: vec![NamespaceNode::Type(wrapper_name)],
                     parameters: vec![],
                 }],
             },
             None => FullyQualifiedTypeReference {
                 type_name: vec![
-                    "java".to_string(),
-                    "util".to_string(),
-                    "ArrayList".to_string(),
+                    NamespaceNode::Package("java".to_string()),
+                    NamespaceNode::Package("util".to_string()),
+                    NamespaceNode::Type("ArrayList".to_string()),
                 ],
                 parameters: vec![target_type],
             },
@@ -149,7 +154,7 @@ impl Language for JavaLanguage {
     }
 
     fn fully_qualified_type_ref(name: &FullyQualifiedTypeReference) -> String {
-        name.type_name.join(".")
+        name.type_name.iter().map(|n| n.name()).join(".")
     }
 
     fn template_name(template: &Template) -> String {
@@ -165,11 +170,15 @@ impl Language for JavaLanguage {
         "."
     }
 
-    fn add_type_to_namespace(_is_nested_type: bool, type_name: &str, namespace: &mut Vec<String>) {
-        namespace.push(type_name.to_case(Case::UpperCamel))
+    fn add_type_to_namespace(
+        _is_nested_type: bool,
+        type_name: &str,
+        namespace: &mut Vec<NamespaceNode>,
+    ) {
+        namespace.push(NamespaceNode::Type(type_name.to_case(Case::UpperCamel)))
     }
 
-    fn reset_namespace(namespace: &mut Vec<String>) {
+    fn reset_namespace(namespace: &mut Vec<NamespaceNode>) {
         // resets the namespace by removing current abstract dta type name
         namespace.pop();
     }
@@ -181,7 +190,7 @@ impl Language for JavaLanguage {
             &target_type.string_representation::<JavaLanguage>(),
         ) {
             Some(wrapper_name) => FullyQualifiedTypeReference {
-                type_name: vec![wrapper_name],
+                type_name: vec![NamespaceNode::Type(wrapper_name)],
                 parameters: vec![],
             },
             None => target_type,
@@ -271,7 +280,7 @@ impl Language for RustLanguage {
         target_type: FullyQualifiedTypeReference,
     ) -> FullyQualifiedTypeReference {
         FullyQualifiedTypeReference {
-            type_name: vec!["Vec".to_string()],
+            type_name: vec![NamespaceNode::Type("Vec".to_string())],
             parameters: vec![target_type],
         }
     }
@@ -284,7 +293,7 @@ impl Language for RustLanguage {
     }
 
     fn fully_qualified_type_ref(name: &FullyQualifiedTypeReference) -> String {
-        name.type_name.join("::")
+        name.type_name.iter().map(|n| n.name()).join("::")
     }
 
     fn template_name(template: &Template) -> String {
@@ -304,7 +313,11 @@ impl Language for RustLanguage {
         "::"
     }
 
-    fn add_type_to_namespace(is_nested_type: bool, type_name: &str, namespace: &mut Vec<String>) {
+    fn add_type_to_namespace(
+        is_nested_type: bool,
+        type_name: &str,
+        namespace: &mut Vec<NamespaceNode>,
+    ) {
         // e.g. For example there is a `NestedType` inside `Foo` struct. Rust code generation also generates similar modules for the generated structs.
         // ```rust
         // mod foo {
@@ -323,24 +336,25 @@ impl Language for RustLanguage {
                 // Assume we have the current namespace as `foo::Foo`
                 // then the following step will remove `Foo` from the path for nested type.
                 // So that the final namespace path for `NestedType` will become `foo::nested_type::NestedType`
-                if !last_value.is_case(Case::Snake) {
+                if !matches!(last_value, NamespaceNode::Package(_)) {
                     // if the last value is not module name then pop the type name from namespace
                     namespace.pop(); // Remove the parent struct/enum
                 }
             }
         }
-        namespace.push(type_name.to_case(Case::Snake)); // Add this type's module name to the namespace path
-        namespace.push(type_name.to_case(Case::UpperCamel)) // Add this type itself to the namespace path
+        namespace.push(NamespaceNode::Package(type_name.to_case(Case::Snake))); // Add this type's module name to the namespace path
+        namespace.push(NamespaceNode::Type(type_name.to_case(Case::UpperCamel)))
+        // Add this type itself to the namespace path
     }
 
-    fn reset_namespace(namespace: &mut Vec<String>) {
+    fn reset_namespace(namespace: &mut Vec<NamespaceNode>) {
         // Resets the namespace by removing current abstract data type name and module name
         if let Some(last_value) = namespace.last() {
             // Check if it is a type then pop the type and module
-            if last_value.is_case(Case::Snake) {
+            if matches!(last_value, NamespaceNode::Package(_)) {
                 // if this is a module then only pop once for the module
                 namespace.pop();
-            } else if last_value.is_case(Case::UpperCamel) {
+            } else if matches!(last_value, NamespaceNode::Type(_)) {
                 namespace.pop();
                 if !namespace.is_empty() {
                     namespace.pop();


### PR DESCRIPTION
### Description of changes:
This PR fixes namespace for nested sequence types and adds support for nested types in sequence and scalar templates.

### List of changes:
- [Modified util_macros.templ to use fully-qualified_type_name](https://github.com/amazon-ion/ion-cli/commit/fd67723354c05ae6164214753feee3f794136e4c)
- [Modified fully_qualified_type_ref method to return `FullyQualifiedTypeReference`](https://github.com/amazon-ion/ion-cli/commit/03e3c7ece33ef246d02eaa4298e9fb1732064e1a)
  - Previously this returned `Option<FullyQualifiedTypeReference>`
- [Modifies add_namespace and reset_namespace](https://github.com/amazon-ion/ion-cli/commit/fede33b2bbd97b3f7acef16c82b5f0b06fc1c8d9)
    * Adds check for last value to verify if its module or type name
    * Adds check for empty namespace
- [Modifies generator for sequence type namespace](https://github.com/amazon-ion/ion-cli/commit/7e73ed07582228c23497038fea0be5383c219737)
    * Sequence ADT does not use separate class for nested sequences.Hence,
    modifies the namespace for this in `build_sequence_from_constraints`.
- [Modified templates for nested types in sequence and scalar](https://github.com/amazon-ion/ion-cli/commit/8450e9df32f4f37b174fe9dac4f92309bd6afbb9)

### Test:
Adds a new test case `sequence_with_enum_element` this verified both sequence namespace bugfix and support for nested types in sequence.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
