### PR TITLE
Adds som README and CLI option changes for code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # `ion-cli`
+
 [![Crate](https://img.shields.io/crates/v/ion-cli.svg)](https://crates.io/crates/ion-cli)
 [![License](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/amazon-ion/ion-cli/blob/main/LICENSE)
 [![CI Build](https://github.com/amazon-ion/ion-cli/workflows/CI%20Build/badge.svg)](https://github.com/amazon-ion/ion-cli/actions?query=workflow%3A%22CI+Build%22)
@@ -11,7 +12,8 @@ for working with [the Ion data format](https://amzn.github.io/ion-docs/docs/spec
 * [Examples](#examples)
     * [Viewing the contents of an Ion file](#viewing-the-contents-of-an-ion-file)
     * [Converting between Ion formats](#converting-between-ion-formats)
-    * [Converting between Ion and other formats with `to` and `from`](#converting-between-ion-and-other-formats-with-to-and-from)
+    * [Converting between Ion and other formats with `to` and
+      `from`](#converting-between-ion-and-other-formats-with-to-and-from)
     * [Analyzing binary Ion file encodings with `inspect`](#analyzing-binary-ion-file-encodings-with-inspect)
 * [Installation](#installation)
     * [via `brew`](#via-brew)
@@ -183,12 +185,6 @@ subcommand) of `ion-cli`, run:
 
 ```bash
 brew install ion-cli --HEAD
-```
-
-If you are looking into accessing all features with `cargo` (including `experimental` features) of `ion-cli`, run:
-
-```shell
-cargo install ion-cli --all-features
 ```
 
 Then make sure that `~/.cargo/bin` is on your `$PATH`. You can confirm that it

--- a/code-gen-projects/README.md
+++ b/code-gen-projects/README.md
@@ -103,7 +103,8 @@ Here are the steps to follow for running tests:
        environment variable.
     2. If you installed with `cargo` then your executable would be in `$HOME/.cargo/bin` and you need to setup the
        environment variable `ION_CLI` to point to the executable's path. If you need latest commits from cargo which are
-       not released yet, then do `cargo install ion-cli --git https://github.com/amazon-ion/ion-cli.git`.
+       not released yet, then do `cargo install ion-cli --git https://github.com/amazon-ion/ion-cli.git` or
+       `brew install ion-cli --HEAD`.
 2. All the tests uses an environment variable `ION_INPUT` which has the path to input Ion files. So if you want to
    test out this project locally set the environment variable `ION_INPUT` to point to `code-gen-projects/input.`_
 3. `cd code-gen-projects/java/code-gen-demo`
@@ -173,9 +174,6 @@ fn main() {
     println!("cargo:rerun-if-changed=schema/");
 }
 ```
-
-_Note: Code generation subcommand `generate` is under a feature flag. It is available
-through `brew install ion-cli` or `cargo install ion-cli`._
 
 ### Tests
 

--- a/code-gen-projects/README.md
+++ b/code-gen-projects/README.md
@@ -83,9 +83,6 @@ tasks {
 }
 ```
 
-_Note: Code generation subcommand `generate` is under a feature flag. It is available
-through `brew install ion-cli --HEAD` or `cargo install ion-cli --all-features`._
-
 ### Tests
 
 The tests for the generated code are defined in `CodeGenTests.java`. It has the following tests:
@@ -101,12 +98,12 @@ The tests for the generated code are defined in `CodeGenTests.java`. It has the 
 
 Here are the steps to follow for running tests:
 
-1. Install ion-cli with either `brew install ion-cli --HEAD` or `cargo install ion-cli --all-features`.
+1. Install ion-cli with either `brew install ion-cli` or `cargo install ion-cli`.
     1. If you installed with brew then your executable is there in `ion` and you don't need to set up `ION_CLI`
        environment variable.
     2. If you installed with `cargo` then your executable would be in `$HOME/.cargo/bin` and you need to setup the
        environment variable `ION_CLI` to point to the executable's path. If you need latest commits from cargo which are
-       not released yet, then do `cargo install ion-cli --all-features --git https://github.com/amazon-ion/ion-cli.git`.
+       not released yet, then do `cargo install ion-cli --git https://github.com/amazon-ion/ion-cli.git`.
 2. All the tests uses an environment variable `ION_INPUT` which has the path to input Ion files. So if you want to
    test out this project locally set the environment variable `ION_INPUT` to point to `code-gen-projects/input.`_
 3. `cd code-gen-projects/java/code-gen-demo`
@@ -178,7 +175,7 @@ fn main() {
 ```
 
 _Note: Code generation subcommand `generate` is under a feature flag. It is available
-through `brew install ion-cli --HEAD` or `cargo install ion-cli --all-features`._
+through `brew install ion-cli` or `cargo install ion-cli`._
 
 ### Tests
 
@@ -194,12 +191,12 @@ The tests for the generated code are defined in `tests` module in `lib.rs`. It h
 
 Here are the steps to follow for running tests:
 
-1. Install ion-cli with either `brew install ion-cli --HEAD` or `cargo install ion-cli --all-features`.
+1. Install ion-cli with either `brew install ion-cli` or `cargo install ion-cli`.
     1. If you installed with brew then your executable is there in `ion` and you need to setup the
        environment variable `ION_CLI` to point to the executable's path.
     2. If you installed with `cargo` then your executable would be in `$HOME/.cargo/bin` and you need to setup the
        environment variable `ION_CLI` to point to the executable's path. If you need latest commits from cargo which are
-       not released yet, then do `cargo install ion-cli --all-features --git https://github.com/amazon-ion/ion-cli.git`.
+       not released yet, then do `cargo install ion-cli --git https://github.com/amazon-ion/ion-cli.git`.
 2. `cd code-gen-projects/rust/code-gen-demo`
 3. Finally, to run the tests, just do:
 

--- a/code-gen-projects/java/code-gen-demo/build.gradle.kts
+++ b/code-gen-projects/java/code-gen-demo/build.gradle.kts
@@ -44,7 +44,7 @@ tasks {
                 "-X", "generate",
                 "-l", "java",
                 "-n", "org.example",
-                "-d", ionSchemaSourceCodeDir,
+                "-A", ionSchemaSourceCodeDir,
                 "-o", generatedIonSchemaModelDir,
             )
             .workingDir(rootProject.projectDir)

--- a/code-gen-projects/rust/code-gen-demo/build.rs
+++ b/code-gen-projects/rust/code-gen-demo/build.rs
@@ -16,7 +16,7 @@ fn main() {
         .arg("generate")
         .arg("-l")
         .arg("rust")
-        .arg("-d")
+        .arg("-A")
         .arg(format!("{}/../../schema", crate_dir))
         .arg("-o")
         .arg(&out_dir);

--- a/src/bin/ion/commands/generate/mod.rs
+++ b/src/bin/ion/commands/generate/mod.rs
@@ -38,8 +38,6 @@ impl IonCliCommand for GenerateCommand {
     }
 
     fn configure_args(&self, command: Command) -> Command {
-        let schema_options_header = "Selecting a schema";
-
         command
             .arg(
                 Arg::new("output")
@@ -65,10 +63,9 @@ impl IonCliCommand for GenerateCommand {
             )
             .arg(
                 Arg::new("authority")
-                    .help_heading(schema_options_header)
                     .long("authority")
                     .short('A')
-                    .required(false)
+                    .required(true)
                     .action(ArgAction::Append)
                     .value_name("directory")
                     .value_hint(ValueHint::DirPath)

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -272,7 +272,7 @@ mod code_gen_tests {
             "java",
             "--namespace",
             "org.example",
-            "--directory",
+            "--authority",
             temp_dir.path().to_str().unwrap(),
         ]);
         let command_assert = cmd.assert();


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
This PR works on adding README change and CLI options change for code generation.

### List of changes:
- [Adds README changes](https://github.com/amazon-ion/ion-cli/commit/e60f854959216b4dede1dcc1fa72c0ac4cd0e3a6)
- [Adds changes for generate subcommand options](https://github.com/amazon-ion/ion-cli/commit/23373d7da7def5c0a9ab09d92f5997b78a0f8905)
  - changes CLI options for `generate` subcommand similar to schema subcommand.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
