### PR TITLE
Adds ion eq command

### DIFF
--- a/src/bin/ion/commands/inspect.rs
+++ b/src/bin/ion/commands/inspect.rs
@@ -1467,7 +1467,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
             ephemeral_value_style().clone()
         };
 
-        self.write_with_style(style.clone(), format!("{formatted_value}"))?;
+        self.write_with_style(style.clone(), &formatted_value)?;
         self.write_with_style(style.clone().set_underline(false).clone(), delimiter)?;
         self.with_style(comment_style(), |this| {
             comment_fn(this.output, ValueExpr::ValueLiteral(value.expanded()))?;


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

Adds an `ion eq` command to test whether two Ion streams are equal.

I'm not entirely sure of the API. Currently, there are option flags to select an output method (bool to stdout, exitcode, or both), but we could also separate this into two different commands (`eq` and `eq!` that each support only one of the output methods) with minimal code changes.

In addition, I'm not entirely satisfied with the "input mode" selection, but we might be able to overlook that given that I've included an automatic input type detection that should correctly detect "file", "Ion", or "hex" for any non-trivial input, and most trivial inputs.

Additional Changes:
* Exit Codes - `clap` uses `2` for a usage error. I have tried to reserve the `1` exit code for "mismatch" according to the convention in https://www.gnu.org/software/libc/manual/html_node/Exit-Status.html, so all other errors use exit code 3.
* Added a step to display the versions of cargo, clippy, and rustfmt in the GHA workflow.
* `hex_reader.rs` had changes that are entirely clippy and/or rustfmt changes.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
