### PR TITLE
Adds `jq` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +957,8 @@ dependencies = [
  "ion-rs",
  "ion-schema",
  "itertools 0.13.0",
+ "jaq-core",
+ "jaq-std",
  "lowcharts",
  "pager",
  "rstest",
@@ -1032,6 +1040,33 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jaq-core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51051f78cd2da8007b6c6f618ce387b4d0b18f6da81812dcb12983afb5bd048b"
+dependencies = [
+ "dyn-clone",
+ "once_cell",
+ "typed-arena",
+]
+
+[[package]]
+name = "jaq-std"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df355eccf9f27755ebc5d0b220d4878b7017349b904acde126909155ba33fba1"
+dependencies = [
+ "aho-corasick",
+ "base64 0.22.1",
+ "chrono",
+ "jaq-core",
+ "libm",
+ "log",
+ "regex-lite",
+ "urlencoding",
+]
 
 [[package]]
 name = "jobserver"
@@ -1447,6 +1482,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
@@ -1876,6 +1917,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,6 +1995,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ zstd = "0.13.0"
 termcolor = "1.4.1"
 derive_builder = "0.20.0"
 itertools = "0.13.0"
+jaq-core = "2.1.1"
+jaq-std = "2.1.0"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 pager = "0.16.1"

--- a/src/bin/ion/commands/jq.rs
+++ b/src/bin/ion/commands/jq.rs
@@ -1,0 +1,385 @@
+use crate::commands::{CommandIo, IonCliCommand, WithIonCliArgument, ION_VERSION_ARG_ID};
+use crate::input::CommandInput;
+use crate::output::CommandOutput;
+use anyhow::bail;
+use clap::{Arg, ArgMatches, Command};
+use ion_rs::{
+    v1_0, AnyEncoding, Element, ElementReader, Format, IonData, IonEncoding, List, Reader,
+    Sequence, TextFormat, Writer,
+};
+use jaq_core::path::Opt;
+use jaq_core::val::Range;
+use jaq_core::{RcIter, ValR, ValX};
+use std::cmp::Ordering;
+use std::fmt::{Display, Formatter};
+use std::ops::{Add, Deref, Div, Mul, Neg, Rem, Sub};
+use std::str::FromStr;
+
+pub struct JqCommand;
+
+impl IonCliCommand for JqCommand {
+    fn is_stable(&self) -> bool {
+        false
+    }
+
+    fn is_porcelain(&self) -> bool {
+        false
+    }
+
+    fn name(&self) -> &'static str {
+        "jq"
+    }
+
+    fn about(&self) -> &'static str {
+        "A version of `jq` extended to support Ion streams. (See: jqlang.org for details.)"
+    }
+
+    fn configure_args(&self, command: Command) -> Command {
+        // Same flags as `cat`, but with an added `--values` flag to specify the number of values to
+        // write.
+        command
+            .with_input()
+            .with_output()
+            .with_format()
+            .with_ion_version()
+            .arg(
+                Arg::new("expr")
+                    .long("expr")
+                    .short('e')
+                    .default_value(".[]")
+                    .help("A `jq` expression to evaluate"),
+            )
+    }
+
+    fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> anyhow::Result<()> {
+        // --format pretty|text|lines|binary
+        // `clap` validates the specified format and provides a default otherwise.
+        // TODO: Use the specified output format
+        let format: Format = match args.get_one::<String>("format").unwrap().as_str() {
+            "text" => Format::Text(TextFormat::Compact),
+            "lines" => Format::Text(TextFormat::Lines),
+            "pretty" => Format::Text(TextFormat::Pretty),
+            "binary" => Format::Binary,
+            unrecognized => bail!("unsupported format '{unrecognized}'"),
+        };
+        // TODO: Use the specified Ion version
+        let _encoding = match (
+            args.get_one::<String>(ION_VERSION_ARG_ID).unwrap().as_str(),
+            format,
+        ) {
+            ("1.0", Format::Text(_)) => IonEncoding::Text_1_0,
+            ("1.0", Format::Binary) => IonEncoding::Binary_1_0,
+            ("1.1", Format::Text(_)) => IonEncoding::Text_1_1,
+            ("1.1", Format::Binary) => IonEncoding::Binary_1_1,
+            (unrecognized, _) => bail!("unrecognized Ion version '{unrecognized}'"),
+        };
+
+        let jq_expr = args.get_one::<String>("expr").unwrap().as_str();
+
+        CommandIo::new(args).for_each_input(|output, input| {
+            evaluate_jq_expr(jq_expr, input, output)?;
+            Ok(())
+        })
+    }
+}
+
+fn evaluate_jq_expr(
+    jq_expr: &str,
+    input: CommandInput,
+    output: &mut CommandOutput,
+) -> anyhow::Result<()> {
+    use jaq_core::load::{Arena, File, Loader};
+    let program = File {
+        code: jq_expr, // a jq expression like ".[]"
+        path: (),      // For error reporting, but not currently used by this program
+    };
+
+    // If we wanted to define our own Ion-centric stdlib methods, we'd do something like:
+    //    Loader::new(jaq_std::defs().chain(jaq_ion::defs()))
+    let loader = Loader::new(jaq_std::defs());
+    let arena = Arena::default();
+
+    // parse the filter
+    let modules = loader.load(&arena, program).unwrap();
+
+    // compile the filter
+    let filter = jaq_core::Compiler::default()
+        // Similar to `defs()` above, this would be our opportunity to extend the built-in filters
+        .with_funs(jaq_std::funs::<JaqElement>())
+        .compile(modules)
+        .unwrap();
+
+    // TODO: The setup above is happening once per input, but could probably happen once per run.
+
+    let mut reader = Reader::new(AnyEncoding, input.into_source())?;
+    let input_elements = reader.read_all_elements()?;
+    let ion_stream_as_element = List::from(input_elements).into();
+
+    let inputs = RcIter::new(core::iter::empty());
+    // iterator over the output values
+    let out = filter.run((jaq_core::Ctx::new([], &inputs), ion_stream_as_element));
+
+    let mut writer = Writer::new(
+        v1_0::Text.with_format(TextFormat::Pretty), // TODO: Use specified version
+        output,
+    )?;
+
+    for value in out {
+        match value {
+            Ok(element) => {
+                writer.write(&element.0)?;
+            }
+            Err(e) => {
+                bail!("jq processing failed: {e}");
+            }
+        }
+    }
+    writer.close()?;
+    Ok(())
+}
+
+/// Wraps an `Element` so we can:
+///  1. Define implementations of common traits like `Ord` and `Eq` without `Element` itself needing to.
+///  2. Keep all logic related to `jq` behavior in one place.
+#[derive(Clone, Eq, Debug)]
+struct JaqElement(Element);
+
+// Anything that can be turned into an Element can also be turned into a JaqElement
+impl<T> From<T> for JaqElement
+where
+    Element: From<T>,
+{
+    fn from(value: T) -> Self {
+        let element: Element = value.into();
+        JaqElement(element)
+    }
+}
+
+// When we have a JaqElement, we can call methods on the underlying Element
+impl Deref for JaqElement {
+    type Target = Element;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// jaq expects errors to include a value of the same type as Ok(value), but the error value
+// may represent an error message, stack trace, or something else. In this impl, it's currently
+// used to return an error message.
+type JaqError = jaq_core::Error<JaqElement>;
+
+// Convenience method to return a `jaq_core::ValR` (value result) with an error.
+fn jaq_error(e: impl Into<Element>) -> ValR<JaqElement> {
+    Err(jaq_err(e))
+}
+
+// Convenience method to return a bare `JaqError`, not wrapped in a Result::Err.
+// This is useful inside closures like `ok_or_else`.
+fn jaq_err(e: impl Into<Element>) -> JaqError {
+    JaqError::new(e.into().into())
+}
+
+impl FromIterator<Self> for JaqElement {
+    fn from_iter<T: IntoIterator<Item = Self>>(iter: T) -> Self {
+        let items = Sequence::from_iter(iter.into_iter().map(|je| je.0));
+        let element = Element::from(List::from_iter(items));
+        JaqElement(element)
+    }
+}
+
+impl PartialEq<Self> for JaqElement {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl PartialOrd for JaqElement {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(IonData::from(self).cmp(&IonData::from(other)))
+    }
+}
+
+// === Math operator behaviors ===
+
+impl Add for JaqElement {
+    type Output = ValR<Self>;
+
+    fn add(self, _rhs: Self) -> Self::Output {
+        todo!()
+    }
+}
+
+impl Sub for JaqElement {
+    type Output = ValR<Self>;
+
+    fn sub(self, _rhs: Self) -> Self::Output {
+        todo!()
+    }
+}
+
+impl Mul for JaqElement {
+    type Output = ValR<Self>;
+
+    fn mul(self, _rhs: Self) -> Self::Output {
+        todo!()
+    }
+}
+
+impl Div for JaqElement {
+    type Output = ValR<Self>;
+
+    fn div(self, _rhs: Self) -> Self::Output {
+        todo!()
+    }
+}
+
+impl Rem for JaqElement {
+    type Output = ValR<Self>;
+
+    fn rem(self, _rhs: Self) -> Self::Output {
+        todo!()
+    }
+}
+
+impl Neg for JaqElement {
+    type Output = ValR<Self>;
+
+    fn neg(self) -> Self::Output {
+        todo!()
+    }
+}
+
+impl Display for JaqElement {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl jaq_core::ValT for JaqElement {
+    // Going from numeric text to an Element
+    fn from_num(n: &str) -> ValR<Self> {
+        match f64::from_str(n) {
+            Ok(f) => Ok(Element::from(f).into()),
+            Err(_) => jaq_error(format!("invalid number: {n}")),
+        }
+    }
+
+    // Given a sequence of (name, value) pairs, make a 'Map' (or in our case: struct)
+    fn from_map<I: IntoIterator<Item = (Self, Self)>>(iter: I) -> ValR<Self> {
+        let mut strukt = ion_rs::Struct::builder();
+        for (name, value) in iter {
+            let field_name = name.expect_text().map_err(|_| {
+                jaq_err(format!(
+                    "struct field names must be symbols or strings, found {name:?}"
+                ))
+            })?;
+            strukt = strukt.with_field(field_name, value.0);
+        }
+
+        Ok(strukt.build().into())
+    }
+
+    // Iterate over the child values of `self`.
+    fn values(self) -> Box<dyn Iterator<Item = ValR<Self>>> {
+        use ion_rs::Value::*;
+        match self.0.into_value() {
+            List(seq) | SExp(seq) => Box::new(seq.into_iter().map(JaqElement::from).map(Ok)),
+            Struct(strukt) => Box::new(strukt.into_iter().map(|(_, v)| Ok(JaqElement::from(v)))),
+            _ => Box::new(std::iter::empty()),
+        }
+    }
+
+    // Get the child value corresponding to the given index Element.
+    fn index(self, index: &Self) -> ValR<Self> {
+        use ion_rs::Value::*;
+
+        match (self.value(), index.value()) {
+            (List(seq) | SExp(seq), Int(i)) => {
+                let index = i
+                    .expect_usize()
+                    .map_err(|_| jaq_err("index must be usize"))?;
+                let element = seq
+                    .get(index)
+                    .ok_or_else(|| jaq_err("index out of bounds"))?;
+                Ok(JaqElement::from(element.to_owned()))
+            }
+            // TODO: Should we allow indexing into a struct by integer?
+            (Struct(strukt), String(name)) => strukt
+                .get(name)
+                .ok_or_else(|| jaq_err(format!("field name '{name}' not found")))
+                .map(Element::to_owned)
+                .map(JaqElement::from),
+            (Struct(strukt), Symbol(name)) => strukt
+                .get(name)
+                .ok_or_else(|| jaq_err(format!("field name '{name}' not found")))
+                .map(Element::to_owned)
+                .map(JaqElement::from),
+            _ => jaq_error(format!("cannot index into {self:?}")),
+        }
+    }
+
+    // Behavior for slicing containers.
+    fn range(self, _range: Range<&Self>) -> ValR<Self> {
+        todo!()
+    }
+
+    // Map a function over `self`'s child values
+    fn map_values<'a, I: Iterator<Item = ValX<'a, Self>>>(
+        self,
+        _opt: Opt,
+        _f: impl Fn(Self) -> I,
+    ) -> ValX<'a, Self> {
+        todo!()
+    }
+
+    // Map a function over the child value found at the given index
+    fn map_index<'a, I: Iterator<Item = ValX<'a, Self>>>(
+        self,
+        _index: &Self,
+        _opt: Opt,
+        _f: impl Fn(Self) -> I,
+    ) -> ValX<'a, Self> {
+        todo!()
+    }
+
+    // Map a function over a range of child values
+    fn map_range<'a, I: Iterator<Item = ValX<'a, Self>>>(
+        self,
+        _range: Range<&Self>,
+        _opt: Opt,
+        _f: impl Fn(Self) -> I,
+    ) -> ValX<'a, Self> {
+        todo!()
+    }
+
+    // If we want "truthiness" for containers (e.g. empty list -> false), define that here
+    fn as_bool(&self) -> bool {
+        self.0.as_bool().unwrap_or(false)
+    }
+
+    // If the element is a text value, return its text.
+    fn as_str(&self) -> Option<&str> {
+        self.as_text()
+    }
+}
+
+impl Ord for JaqElement {
+    fn cmp(&self, other: &Self) -> Ordering {
+        IonData::from(self).cmp(&IonData::from(other))
+    }
+}
+
+impl jaq_std::ValT for JaqElement {
+    fn into_seq<S: FromIterator<Self>>(self) -> Result<S, Self> {
+        todo!()
+    }
+
+    fn as_isize(&self) -> Option<isize> {
+        todo!()
+    }
+
+    fn as_f64(&self) -> Result<f64, jaq_core::Error<Self>> {
+        todo!()
+    }
+}

--- a/src/bin/ion/commands/jq.rs
+++ b/src/bin/ion/commands/jq.rs
@@ -35,8 +35,6 @@ impl IonCliCommand for JqCommand {
     }
 
     fn configure_args(&self, command: Command) -> Command {
-        // Same flags as `cat`, but with an added `--values` flag to specify the number of values to
-        // write.
         command
             .with_input()
             .with_output()

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod generate;
 pub mod hash;
 pub mod head;
 pub mod inspect;
+pub mod jq;
 pub mod primitive;
 pub mod schema;
 pub mod stats;

--- a/src/bin/ion/main.rs
+++ b/src/bin/ion/main.rs
@@ -15,6 +15,7 @@ use crate::commands::generate::GenerateCommand;
 use crate::commands::hash::HashCommand;
 use crate::commands::head::HeadCommand;
 use crate::commands::inspect::InspectCommand;
+use crate::commands::jq::JqCommand;
 use crate::commands::primitive::PrimitiveCommand;
 use crate::commands::schema::SchemaNamespace;
 use crate::commands::stats::StatsCommand;
@@ -65,6 +66,7 @@ impl IonCliNamespace for RootCommand {
             Box::new(HashCommand),
             Box::new(HeadCommand),
             Box::new(InspectCommand),
+            Box::new(JqCommand),
             Box::new(PrimitiveCommand),
             Box::new(SchemaNamespace),
             Box::new(SymtabNamespace),


### PR DESCRIPTION
Lays the groundwork for an `ion jq` command.

This PR adds a dependency on the `jaq` crate, which provides a `jq` engine, and implements the necessary traits for the `Element` type.  

There are many `todo!()`s left to implement to support `jq` features like math operations. However, many basic commands work:

![image](https://github.com/user-attachments/assets/ddc90a6c-fa6e-4a04-ab6e-06a09934fe81)

There are plenty of open questions around which `jq` flags to support, what the default expression should be, etc.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
