### PR TITLE
Make validate command handle bad Ion input more gracefully

### DIFF
--- a/src/bin/ion/commands/inspect.rs
+++ b/src/bin/ion/commands/inspect.rs
@@ -1467,7 +1467,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
             ephemeral_value_style().clone()
         };
 
-        self.write_with_style(style.clone(), format!("{formatted_value}"))?;
+        self.write_with_style(style.clone(), &formatted_value)?;
         self.write_with_style(style.clone().set_underline(false).clone(), delimiter)?;
         self.with_style(comment_style(), |this| {
             comment_fn(this.output, ValueExpr::ValueLiteral(value.expanded()))?;


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

Now, if you are validating a group of inputs, one input with invalid Ion won't necessarily terminate the whole program. Now, for example, you might get something like this:
```
conformance/data_model/annotations.ion ... ok
conformance/data_model/boolean.ion ... ok
conformance/data_model/decimal.ion ... ERROR: encountered an int whose value was exceeded the supported range: '314159265358979323846264338327950288419716939937510'
conformance/data_model/float.ion ... ok
conformance/data_model/integer.ion ... FAILED
conformance/data_model/null.ion ... ok
```
The `ERROR` indicates that there was an error attempting to read the input. The `FAILED` still indicates that the data is invalid for the given schema.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
