### PR TITLE
Adds helpers to `CommandOutput` to deal with output format&encoding

### DIFF
--- a/src/bin/ion/commands/cat.rs
+++ b/src/bin/ion/commands/cat.rs
@@ -1,8 +1,8 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 use clap::{ArgMatches, Command};
 use ion_rs::*;
 
-use crate::commands::{CommandIo, IonCliCommand, WithIonCliArgument, ION_VERSION_ARG_ID};
+use crate::commands::{CommandIo, IonCliCommand, WithIonCliArgument};
 use crate::transcribe::write_all_as;
 
 pub struct CatCommand;
@@ -34,28 +34,10 @@ impl IonCliCommand for CatCommand {
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
-        // --format pretty|text|lines|binary
-        // `clap` validates the specified format and provides a default otherwise.
-        let format: Format = match args.get_one::<String>("format").unwrap().as_str() {
-            "text" => Format::Text(TextFormat::Compact),
-            "lines" => Format::Text(TextFormat::Lines),
-            "pretty" => Format::Text(TextFormat::Pretty),
-            "binary" => Format::Binary,
-            unrecognized => bail!("unsupported format '{unrecognized}'"),
-        };
-        let encoding = match (
-            args.get_one::<String>(ION_VERSION_ARG_ID).unwrap().as_str(),
-            format,
-        ) {
-            ("1.0", Format::Text(_)) => IonEncoding::Text_1_0,
-            ("1.0", Format::Binary) => IonEncoding::Binary_1_0,
-            ("1.1", Format::Text(_)) => IonEncoding::Text_1_1,
-            ("1.1", Format::Binary) => IonEncoding::Binary_1_1,
-            (unrecognized, _) => bail!("unrecognized Ion version '{unrecognized}'"),
-        };
-
-        CommandIo::new(args).for_each_input(|output, input| {
+        CommandIo::new(args)?.for_each_input(|output, input| {
             let mut reader = Reader::new(AnyEncoding, input.into_source())?;
+            let encoding = *output.encoding();
+            let format = *output.format();
             write_all_as(&mut reader, output, encoding, format)?;
             Ok(())
         })

--- a/src/bin/ion/commands/hash.rs
+++ b/src/bin/ion/commands/hash.rs
@@ -89,7 +89,7 @@ impl IonCliCommand for HashCommand {
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
-        CommandIo::new(args).for_each_input(|output, input| {
+        CommandIo::new(args)?.for_each_input(|output, input| {
             let mut reader = Reader::new(AnyEncoding, input.into_source())?;
 
             let hasher = if let Some(hasher) = args.get_one::<DigestType>("hash") {

--- a/src/bin/ion/commands/head.rs
+++ b/src/bin/ion/commands/head.rs
@@ -1,8 +1,8 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 use clap::{value_parser, Arg, ArgMatches, Command};
-use ion_rs::{AnyEncoding, Format, IonEncoding, Reader, TextFormat};
+use ion_rs::{AnyEncoding, Reader};
 
-use crate::commands::{CommandIo, IonCliCommand, WithIonCliArgument, ION_VERSION_ARG_ID};
+use crate::commands::{CommandIo, IonCliCommand, WithIonCliArgument};
 use crate::transcribe::write_n_as;
 
 pub struct HeadCommand;
@@ -47,30 +47,12 @@ impl IonCliCommand for HeadCommand {
         //TODO: Multiple file handling in classic `head` includes a header per file.
         // https://github.com/amazon-ion/ion-cli/issues/48
 
-        // --format pretty|text|lines|binary
-        // `clap` validates the specified format and provides a default otherwise.
-        let format: Format = match args.get_one::<String>("format").unwrap().as_str() {
-            "text" => Format::Text(TextFormat::Compact),
-            "lines" => Format::Text(TextFormat::Lines),
-            "pretty" => Format::Text(TextFormat::Pretty),
-            "binary" => Format::Binary,
-            unrecognized => bail!("unsupported format '{unrecognized}'"),
-        };
-        let encoding = match (
-            args.get_one::<String>(ION_VERSION_ARG_ID).unwrap().as_str(),
-            format,
-        ) {
-            ("1.0", Format::Text(_)) => IonEncoding::Text_1_0,
-            ("1.0", Format::Binary) => IonEncoding::Binary_1_0,
-            ("1.1", Format::Text(_)) => IonEncoding::Text_1_1,
-            ("1.1", Format::Binary) => IonEncoding::Binary_1_1,
-            (unrecognized, _) => bail!("unrecognized Ion version '{unrecognized}'"),
-        };
-
         let num_values = *args.get_one::<usize>("values").unwrap();
 
-        CommandIo::new(args).for_each_input(|output, input| {
+        CommandIo::new(args)?.for_each_input(|output, input| {
             let mut reader = Reader::new(AnyEncoding, input.into_source())?;
+            let encoding = *output.encoding();
+            let format = *output.format();
             write_n_as(&mut reader, output, encoding, format, num_values)?;
             Ok(())
         })

--- a/src/bin/ion/commands/inspect.rs
+++ b/src/bin/ion/commands/inspect.rs
@@ -138,7 +138,7 @@ impl IonCliCommand for InspectCommand {
 
         let hide_expansion = args.get_flag("hide-expansion");
 
-        let mut command_io = CommandIo::new(args);
+        let mut command_io = CommandIo::new(args)?;
 
         let mut read_as_hex_string = false;
         if let Some(hex_args) = args.get_many::<String>("hex-input") {

--- a/src/bin/ion/commands/schema/validate.rs
+++ b/src/bin/ion/commands/schema/validate.rs
@@ -122,7 +122,7 @@ impl IonCliCommand for ValidateCommand {
 
         let mut all_valid = true;
 
-        CommandIo::new(args).for_each_input(|output, input| {
+        CommandIo::new(args)?.for_each_input(|output, input| {
             let input_name = input.name().to_string();
             // Output always uses 'lines' format so that we can have one output line per grouped input.
             // If the user wants something different, use 'ion cat' to change it.

--- a/src/bin/ion/commands/stats.rs
+++ b/src/bin/ion/commands/stats.rs
@@ -45,7 +45,7 @@ impl IonCliCommand for StatsCommand {
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
-        CommandIo::new(args).for_each_input(|_output, input| {
+        CommandIo::new(args)?.for_each_input(|_output, input| {
             let mut reader = SystemReader::new(AnyEncoding, input.into_source());
             analyze(&mut reader, &mut std::io::stdout(), args)
         })

--- a/src/bin/ion/commands/symtab/filter.rs
+++ b/src/bin/ion/commands/symtab/filter.rs
@@ -40,7 +40,7 @@ impl IonCliCommand for SymtabFilterCommand {
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
         let lift_requested = args.get_flag("lift");
-        CommandIo::new(args).for_each_input(|output, input| {
+        CommandIo::new(args)?.for_each_input(|output, input| {
             let mut system_reader = SystemReader::new(AnyEncoding, input.into_source());
             filter_out_user_data(&mut system_reader, output, lift_requested)
         })

--- a/src/bin/ion/commands/to/json.rs
+++ b/src/bin/ion/commands/to/json.rs
@@ -36,7 +36,7 @@ impl IonCliCommand for ToJsonCommand {
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
-        CommandIo::new(args).for_each_input(|output, input| {
+        CommandIo::new(args)?.for_each_input(|output, input| {
             let input_name = input.name().to_owned();
             let mut reader = Reader::new(AnyEncoding, input.into_source())
                 .with_context(|| format!("Input file '{}' was not valid Ion.", input_name))?;

--- a/src/bin/ion/output.rs
+++ b/src/bin/ion/output.rs
@@ -1,28 +1,116 @@
 use crate::file_writer::FileWriter;
+use anyhow::bail;
+use ion_rs::{v1_0, v1_1, Encoding, Format, IonEncoding, Writer};
+use ion_rs::{IonResult, SequenceWriter, WriteAsIon};
+use itertools::Itertools;
 use std::io::Write;
 use termcolor::{ColorSpec, StandardStreamLock, WriteColor};
 
 /// Statically dispatches writes to either an output file or STDOUT while also supporting `termcolor`
 /// style escape sequences when the target is a TTY.
 pub enum CommandOutput<'a> {
-    StdOut(StandardStreamLock<'a>),
-    File(FileWriter),
+    StdOut(StandardStreamLock<'a>, CommandOutputSpec),
+    File(FileWriter, CommandOutputSpec),
+}
+
+pub enum CommandOutputWriter<'a, 'b> {
+    Text_1_0(Writer<v1_0::Text, &'b mut CommandOutput<'a>>),
+    Binary_1_0(Writer<v1_0::Binary, &'b mut CommandOutput<'a>>),
+    Text_1_1(Writer<v1_1::Text, &'b mut CommandOutput<'a>>),
+    Binary_1_1(Writer<v1_1::Binary, &'b mut CommandOutput<'a>>),
+}
+
+impl<'a, 'b> CommandOutputWriter<'a, 'b> {
+    pub fn write<V: WriteAsIon>(&mut self, value: V) -> IonResult<&mut Self> {
+        match self {
+            CommandOutputWriter::Text_1_0(w) => w.write(value).map(|_| ())?,
+            CommandOutputWriter::Binary_1_0(w) => w.write(value).map(|_| ())?,
+            CommandOutputWriter::Text_1_1(w) => w.write(value).map(|_| ())?,
+            CommandOutputWriter::Binary_1_1(w) => w.write(value).map(|_| ())?,
+        }
+
+        Ok(self)
+    }
+
+    /// Writes bytes of previously encoded values to the output stream.
+    pub fn flush(&mut self) -> IonResult<()> {
+        match self {
+            CommandOutputWriter::Text_1_0(w) => w.flush(),
+            CommandOutputWriter::Binary_1_0(w) => w.flush(),
+            CommandOutputWriter::Text_1_1(w) => w.flush(),
+            CommandOutputWriter::Binary_1_1(w) => w.flush(),
+        }
+    }
+
+    pub fn close(self) -> IonResult<()> {
+        match self {
+            CommandOutputWriter::Text_1_0(w) => w.close().map(|_| ())?,
+            CommandOutputWriter::Binary_1_0(w) => w.close().map(|_| ())?,
+            CommandOutputWriter::Text_1_1(w) => w.close().map(|_| ())?,
+            CommandOutputWriter::Binary_1_1(w) => w.close().map(|_| ())?,
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> CommandOutput<'a> {
+    pub fn spec(&self) -> &CommandOutputSpec {
+        match self {
+            CommandOutput::StdOut(_, spec) => spec,
+            CommandOutput::File(_, spec) => spec,
+        }
+    }
+
+    pub fn format(&self) -> &Format {
+        &self.spec().format
+    }
+
+    pub fn encoding(&self) -> &IonEncoding {
+        &self.spec().encoding
+    }
+
+    pub fn as_writer<'b>(&'b mut self) -> anyhow::Result<CommandOutputWriter<'a, 'b>> {
+        let CommandOutputSpec { format, encoding } = *self.spec();
+
+        Ok(match (encoding, format) {
+            (IonEncoding::Text_1_0, Format::Text(text_format)) => CommandOutputWriter::Text_1_0(
+                Writer::new(v1_0::Text.with_format(text_format), self)?,
+            ),
+            (IonEncoding::Text_1_1, Format::Text(text_format)) => CommandOutputWriter::Text_1_1(
+                Writer::new(v1_1::Text.with_format(text_format), self)?,
+            ),
+            (IonEncoding::Binary_1_0, Format::Binary) => {
+                CommandOutputWriter::Binary_1_0(Writer::new(v1_0::Binary, self)?)
+            }
+            (IonEncoding::Binary_1_1, Format::Binary) => {
+                CommandOutputWriter::Binary_1_1(Writer::new(v1_1::Binary, self)?)
+            }
+            unrecognized => bail!("unsupported format '{:?}'", unrecognized),
+        })
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct CommandOutputSpec {
+    pub format: Format,
+    pub encoding: IonEncoding,
 }
 
 impl Write for CommandOutput<'_> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         use CommandOutput::*;
         match self {
-            StdOut(stdout) => stdout.write(buf),
-            File(file_writer) => file_writer.write(buf),
+            StdOut(stdout, ..) => stdout.write(buf),
+            File(file_writer, ..) => file_writer.write(buf),
         }
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
         use CommandOutput::*;
         match self {
-            StdOut(stdout) => stdout.flush(),
-            File(file_writer) => file_writer.flush(),
+            StdOut(stdout, ..) => stdout.flush(),
+            File(file_writer, ..) => file_writer.flush(),
         }
     }
 }
@@ -31,24 +119,24 @@ impl WriteColor for CommandOutput<'_> {
     fn supports_color(&self) -> bool {
         use CommandOutput::*;
         match self {
-            StdOut(stdout) => stdout.supports_color(),
-            File(file_writer) => file_writer.supports_color(),
+            StdOut(stdout, ..) => stdout.supports_color(),
+            File(file_writer, ..) => file_writer.supports_color(),
         }
     }
 
     fn set_color(&mut self, spec: &ColorSpec) -> std::io::Result<()> {
         use CommandOutput::*;
         match self {
-            StdOut(stdout) => stdout.set_color(spec),
-            File(file_writer) => file_writer.set_color(spec),
+            StdOut(stdout, ..) => stdout.set_color(spec),
+            File(file_writer, ..) => file_writer.set_color(spec),
         }
     }
 
     fn reset(&mut self) -> std::io::Result<()> {
         use CommandOutput::*;
         match self {
-            StdOut(stdout) => stdout.reset(),
-            File(file_writer) => file_writer.reset(),
+            StdOut(stdout, ..) => stdout.reset(),
+            File(file_writer, ..) => file_writer.reset(),
         }
     }
 }


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

Centralizes some the logic for reading command flags for `--format` and `--ion-version` and provides some helpers for building a `Writer` based on those flags.

```
❯ echo 'foo:: [1, 2, 3] bar:: (a b c) baz:: [2023T, 2024T, 2025T]' | ./target/debug/ion -X jq -e '. [][1]'
2
b
2024T
```

```
❯ echo 'foo:: [1, 2, 3] bar:: (a b c) baz:: [2023T, 2024T, 2025T]' | ./target/debug/ion -X jq --format binary -e '. [][1]'
��ꁃ׆q���b!q
c��%
```

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
