### PR TITLE
Implement `-`, `*`, `/`, `%` for `ion jq`

### DIFF
--- a/src/bin/ion/commands/jq.rs
+++ b/src/bin/ion/commands/jq.rs
@@ -212,9 +212,18 @@ impl Add for JaqElement {
         use Value::*;
 
         let elt: Element = match (lhv, rhv) {
+            // jq treats JSON's untyped null as an additive identity, e.g. 0 / "" / [] / {}
+            (Null(IonType::Null), a) | (a, Null(IonType::Null)) => a.into(),
+
+            // Typed nulls we must handle differently, we can only add similar types
+            (Null(a), Null(b)) if a == b => Null(a).into(),
+            (Null(a), b) | (b, Null(a)) if a == b.ion_type() => b.into(),
+
+            // Sequences and strings concatenate
             (List(a), List(b)) => ion_rs::List::from_iter(a.into_iter().chain(b)).into(),
             (SExp(a), SExp(b)) => ion_rs::SExp::from_iter(a.into_iter().chain(b)).into(),
             (String(a), String(b)) => format!("{}{}", a.text(), b.text()).into(),
+            // Structs merge
             //TODO: Recursively remove duplicate fields, first field position but b and last field wins
             (Struct(a), Struct(b)) => a.clone_builder().with_fields(b.fields()).build().into(),
 
@@ -223,13 +232,6 @@ impl Add for JaqElement {
             (Float(a), Float(b)) => (a + b).into(),
             (Decimal(a), Decimal(b)) => a.add(b).into(),
             (Decimal(a), Int(b)) | (Int(b), Decimal(a)) => a.add(b).into(),
-
-            // jq treats JSON's untyped null as an additive identity, e.g. 0 / "" / [] / {}
-            (Null(IonType::Null), a) | (a, Null(IonType::Null)) => a.into(),
-
-            // Typed nulls we must handle differently, we can only add similar types
-            (Null(a), Null(b)) if a == b => Null(a).into(),
-            (Null(a), b) | (b, Null(a)) if a == b.ion_type() => b.into(),
 
             // Only try potentially lossy Float conversions when we've run out of the other options
             (b, Float(a)) | (Float(a), b)


### PR DESCRIPTION
### Description of changes: Adds support for the `-`, `*`, `/`, and `%` operations in `ion jq`.

Dissimilar numeric types can be used in math operations, with the rules:
1. Operations with `int` and `decimal` => `decimal`
2. Operations with `float` and `int` => `float`
3. Operations with `float` and `decimal` => `float`


Examples:

Given `alias iq='cargo -q run -- -X jq --slurp'`:

#### Subtraction (`-`) (see [jq manual](https://jqlang.org/manual/#subtraction))
> As well as normal arithmetic subtraction on numbers, the `-` operator can be used on arrays to remove all occurrences of the second array's elements from the first array.

| type | input | output |
|--------|--------|--------|
| integer | `echo '1 1' \| iq '.[0] - .[1]'` |  `0` |
| float | `echo '1e0 1e0' \| iq '.[0] - .[1]'` |  `0e0` |
| decimal | `echo '1.0 1.0' \| iq '.[0] - .[1]'` |  `0.0` |
| list | `echo '[1, 2] [2]' \| iq '.[0] - .[1]'` |  `[1,]` |
| sexp | `echo '(1 2) (2)' \| iq '.[0] - .[1]'` |  `(1)` |


Subtraction is not defined for `null`, `struct`, `string`, `bool`, `blob`, `clob`, or `timestamp`. Subtracting dissimilar types is not supported, and gets an error like: 
```plain
❯ echo '1 {a: bar, b: qux}' | iq '.[0] - .[1]'
Error: ion jq: "int (1) and struct ({a: bar, b: qux}) cannot be subtracted"
```

#### Multiplication (`*`)

| type | example | output |
|--------|--------|--------|
| integer | `echo '2 2' \| iq '.[0] * .[1]'` |  `4` |
| float | `echo '2e0 2e0' \| iq '.[0] * .[1]'` |  `4e0` |
| decimal | `echo '2.0 2.0' \| iq '.[0] * .[1]'` |  `4.0` |
| struct | `echo '{a: b, c: d} {c: d, e: f}' \| iq '.[0] * .[1]'` |  `{  a: b,  c: d,  c: d,  e: f, }` |
| integer, string | `echo '"la" 5' \| iq '.[0] * .[1]'` |  `"lalalalala"` |
| integer, symbol | `echo 'la 5' \| iq '.[0] * .[1]'` |  `lalalalala` |

Multiplication is not defined for `null`, `struct`, `bool`, `blob`, `clob`, or `timestamp`. Multiplying dissimilar types is not supported, and gets an error like: 
```plain
❯ echo '1 {a: bar, b: qux}' | iq '.[0] * .[1]'
Error: ion jq: "int (1) and struct ({a: bar, b: qux}) cannot be multiplied"
```

> [!WARNING]
>  The `*` implementation is NOT `jq`-spec compliant for structs. I intend to follow up on that, but would also be happy to disable this functionality for now. 

#### Division (`/`)

| type | example | output |
|--------|--------|--------|
| integer | `echo '4 2' \| iq '.[0] / .[1]'` |  `2` |
| float | `echo '4e0 2e0' \| iq '.[0] / .[1]'` |  `2e0` |
| decimal | `echo '4.0 2.0' \| iq '.[0] / .[1]'` |  `2.` |
| string | `echo '"hello world" " "' \| iq '.[0] / .[1]'` |  `["hello", "world"]` |
| string | `echo hello_world _ \| iq '.[0] / .[1]'` |  `[hello, world]` |

#### Remainder (`%`)
| type | example | output |
|--------|--------|--------|
| integer | `echo '4 3' \| iq '.[0] % .[1]'` |  `1` |
| float | `echo '4e0 35e-1' \| iq '.[0] % .[1]'` |  `5e-1` |
| decimal | `echo '4.0 3.5' \| iq '.[0] % .[1]'` |  `0.5` |
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
