### PR TITLE
Added --detect-timestamps flag to preserve Ion timestamps during JSON roundtrip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swp
 *.swo
 *.swn
+.vscode/

--- a/src/bin/ion/commands/cat.rs
+++ b/src/bin/ion/commands/cat.rs
@@ -4,7 +4,7 @@ use ion_rs::*;
 
 use crate::commands::timestamp_conversion::convert_timestamps;
 use crate::commands::{CommandIo, IonCliCommand, WithIonCliArgument};
-use crate::transcribe::{write_all_as, write_all_as_with_mapper};
+use crate::transcribe::write_all_as;
 
 pub struct CatCommand;
 
@@ -37,23 +37,21 @@ impl IonCliCommand for CatCommand {
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
-        let detect_timestamps = args.get_flag("detect-timestamps");
-        let mapper = if detect_timestamps {
-            Some(convert_timestamps as fn(Element) -> Result<Element>)
+        let mapper = if args.get_flag("detect-timestamps") { // no-op that passes the element through unchanged
+            convert_timestamps
         } else {
-            None
+            |element| Ok(element)
         };
 
         CommandIo::new(args)?.for_each_input(|output, input| {
             let mut reader = Reader::new(AnyEncoding, input.into_source())?;
-            let encoding = *output.encoding();
-            let format = *output.format();
-
-            if detect_timestamps {
-                write_all_as_with_mapper(&mut reader, output, encoding, format, mapper)?;
-            } else {
-                write_all_as(&mut reader, output, encoding, format)?;
-            }
+            write_all_as(
+                &mut reader,
+                output,
+                *output.encoding(),
+                *output.format(),
+                mapper,
+            )?;
             Ok(())
         })
     }

--- a/src/bin/ion/commands/cat.rs
+++ b/src/bin/ion/commands/cat.rs
@@ -58,3 +58,28 @@ impl IonCliCommand for CatCommand {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_timestamp_string_conversion() -> Result<()> {
+        // Test that timestamp-like strings are converted
+        let timestamp_string = Element::from("2023-01-01T00:00:00Z");
+        let result = convert_timestamps(timestamp_string)?;
+        assert_eq!(result.ion_type(), IonType::Timestamp);
+
+        // Test nested timestamp in struct (tests pre-order traversal)
+        let struct_with_timestamp = Element::from(
+            ion_rs::Struct::builder()
+                .with_field("created", "2025-01-01T12:00:00Z")
+                .build(),
+        );
+        let result = convert_timestamps(struct_with_timestamp)?;
+        let created_field = result.as_struct().unwrap().get("created").unwrap();
+        assert_eq!(created_field.ion_type(), IonType::Timestamp);
+
+        Ok(())
+    }
+}

--- a/src/bin/ion/commands/cat.rs
+++ b/src/bin/ion/commands/cat.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use clap::{arg, ArgMatches, Command};
-use ion_rs::serde::de;
 use ion_rs::*;
 
 use crate::commands::timestamp_conversion::convert_timestamps;

--- a/src/bin/ion/commands/cat.rs
+++ b/src/bin/ion/commands/cat.rs
@@ -38,13 +38,8 @@ impl IonCliCommand for CatCommand {
         let transform = None::<fn(Element) -> Result<Element>>;
         CommandIo::new(args)?.for_each_input(|output, input| {
             let mut reader = Reader::new(AnyEncoding, input.into_source())?;
-            write_all_as(
-                &mut reader,
-                output,
-                *output.encoding(),
-                *output.format(),
-                transform,
-            )?;
+            let (encoding, format) = (*output.encoding(), *output.format());
+            write_all_as(&mut reader, output, encoding, format, transform)?;
             Ok(())
         })
     }

--- a/src/bin/ion/commands/cat.rs
+++ b/src/bin/ion/commands/cat.rs
@@ -58,28 +58,3 @@ impl IonCliCommand for CatCommand {
         })
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_timestamp_string_conversion() -> Result<()> {
-        // Test that timestamp-like strings are converted
-        let timestamp_string = Element::from("2023-01-01T00:00:00Z");
-        let result = convert_timestamps(timestamp_string)?;
-        assert_eq!(result.ion_type(), IonType::Timestamp);
-
-        // Test nested timestamp in struct (tests pre-order traversal)
-        let struct_with_timestamp = Element::from(
-            ion_rs::Struct::builder()
-                .with_field("created", "2025-01-01T12:00:00Z")
-                .build(),
-        );
-        let result = convert_timestamps(struct_with_timestamp)?;
-        let created_field = result.as_struct().unwrap().get("created").unwrap();
-        assert_eq!(created_field.ion_type(), IonType::Timestamp);
-
-        Ok(())
-    }
-}

--- a/src/bin/ion/commands/cat.rs
+++ b/src/bin/ion/commands/cat.rs
@@ -37,7 +37,8 @@ impl IonCliCommand for CatCommand {
     }
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
-        let mapper = if args.get_flag("detect-timestamps") { // no-op that passes the element through unchanged
+        let mapper = if args.get_flag("detect-timestamps") {
+            // no-op that passes the element through unchanged
             convert_timestamps
         } else {
             |element| Ok(element)

--- a/src/bin/ion/commands/from/json.rs
+++ b/src/bin/ion/commands/from/json.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::{arg, ArgMatches, Command};
-use ion_rs::{AnyEncoding, Element, Reader};
+use ion_rs::{AnyEncoding, Reader};
 
 use crate::commands::timestamp_conversion::convert_timestamps;
 use crate::commands::{CommandIo, IonCliCommand, WithIonCliArgument};

--- a/src/bin/ion/commands/from/json.rs
+++ b/src/bin/ion/commands/from/json.rs
@@ -18,7 +18,7 @@ impl IonCliCommand for FromJsonCommand {
     }
 
     fn is_stable(&self) -> bool {
-        false // TODO: Should this be true?
+        true
     }
 
     fn is_porcelain(&self) -> bool {

--- a/src/bin/ion/commands/from/json.rs
+++ b/src/bin/ion/commands/from/json.rs
@@ -111,7 +111,7 @@ fn to_ion_element(value: Value, detect_timestamps: bool) -> Result<Element> {
 }
 
 fn is_timestamp_like(s: &str) -> bool {
-    s.len() >= 4 
+    s.len() >= 4
         && s[..4].chars().all(|c| c.is_ascii_digit())
         && (s.contains('T') || (s.len() == 10 && s.matches('-').count() == 2))
         && !(s.len() == 4 && s.chars().all(|c| c.is_ascii_digit()))

--- a/src/bin/ion/commands/from/json.rs
+++ b/src/bin/ion/commands/from/json.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use clap::{arg, ArgMatches, Command};
-use ion_rs::{AnyEncoding, Element, IonType, Reader};
+use ion_rs::{AnyEncoding, Element, Reader};
 
+use crate::commands::timestamp_conversion::convert_timestamps;
 use crate::commands::{CommandIo, IonCliCommand, WithIonCliArgument};
 use crate::input::CommandInput;
 use crate::output::CommandOutput;
@@ -27,7 +28,7 @@ impl IonCliCommand for FromJsonCommand {
 
     fn configure_args(&self, command: Command) -> Command {
         command
-            .arg(arg!(--"detect-timestamps" "Parse ISO 8601 timestamp strings as Ion timestamps"))
+            .arg(arg!(-t --"detect-timestamps" "Preserve Ion timestamps when going from Ion to JSON to Ion"))
             .with_input()
             .with_output()
             .with_format()
@@ -69,74 +70,4 @@ pub fn convert(
     }
 
     writer.close().map_err(Into::into)
-}
-
-fn convert_timestamps(element: Element) -> Result<Element> {
-    Ok(match element.ion_type() {
-        IonType::String => {
-            let s = element.as_string().unwrap();
-            if is_timestamp_like(s) {
-                if let Ok(timestamp_element) = Element::read_one(s.as_bytes()) {
-                    if timestamp_element.ion_type() == IonType::Timestamp {
-                        return Ok(timestamp_element);
-                    }
-                }
-            }
-            element
-        }
-        IonType::List => {
-            let list = element.as_sequence().unwrap();
-            let converted: Result<Vec<_>> = list
-                .elements()
-                .map(|e| convert_timestamps(e.clone()))
-                .collect();
-            Element::from(ion_rs::List::from(converted?))
-        }
-        IonType::Struct => {
-            let struct_val = element.as_struct().unwrap();
-            let mut struct_builder = ion_rs::Struct::builder();
-            for (field, value) in struct_val.fields() {
-                struct_builder =
-                    struct_builder.with_field(field, convert_timestamps(value.clone())?);
-            }
-            Element::from(struct_builder.build())
-        }
-        _ => element,
-    })
-}
-
-/// Heuristic to identify strings that could be Ion timestamps
-///
-/// Ion timestamps follow ISO 8601 format with these constraints:
-/// - Years 0001-9999 (4 digits)
-/// - Precision up to nanoseconds
-/// - Must have date component (YYYY, YYYY-MM, or YYYY-MM-DD)
-///
-/// This function uses position-based checks, which are cheaper compared to string operations:
-/// - Length bounds (4-35 chars for timestamp range)
-/// - Direct character position checks
-fn is_timestamp_like(s: &str) -> bool {
-    let len = s.len();
-
-    // Bounds check, timestamps are 4-35 chars
-    if !(4..=35).contains(&len) {
-        return false;
-    }
-
-    // Must start with 4 digits
-    let bytes = s.as_bytes();
-    if !bytes[0].is_ascii_digit()
-        || !bytes[1].is_ascii_digit()
-        || !bytes[2].is_ascii_digit()
-        || !bytes[3].is_ascii_digit()
-    {
-        return false;
-    }
-
-    match len {
-        4 => false,
-        5..=9 => bytes[len - 1] == b'T',
-        10 => bytes[4] == b'-' && bytes[7] == b'-',
-        _ => len > 10 && bytes[10] == b'T',
-    }
 }

--- a/src/bin/ion/commands/from/json.rs
+++ b/src/bin/ion/commands/from/json.rs
@@ -83,7 +83,9 @@ fn to_ion_element(value: Value, detect_timestamps: bool) -> Result<Element> {
             }
         }
         Value::String(s) => {
+            // Using is_timestamp_like as a heuristic provides a filter that eliminates non-timestamp
             if detect_timestamps && is_timestamp_like(&s) {
+                // Using ion_rs to parse the string to ensure it's a valid timestamp
                 if let Ok(element) = Element::read_one(s.as_bytes()) {
                     if element.ion_type() == ion_rs::IonType::Timestamp {
                         return Ok(element);

--- a/src/bin/ion/commands/from/json.rs
+++ b/src/bin/ion/commands/from/json.rs
@@ -1,8 +1,10 @@
-use anyhow::Result;
-use clap::{ArgMatches, Command};
+use anyhow::{Context, Result};
+use clap::{arg, ArgMatches, Command};
+use ion_rs::{Element, Timestamp};
+use serde_json::{Value, Deserializer};
 
-use crate::commands::cat::CatCommand;
-use crate::commands::{IonCliCommand, WithIonCliArgument};
+use crate::commands::{CommandIo, IonCliCommand, WithIonCliArgument};
+use crate::output::CommandOutput;
 
 pub struct FromJsonCommand;
 
@@ -26,15 +28,141 @@ impl IonCliCommand for FromJsonCommand {
     fn configure_args(&self, command: Command) -> Command {
         // Args must be identical to CatCommand so that we can safely delegate
         command
+            .arg(arg!(--"detect-timestamps" "Parse ISO 8601 timestamp strings as Ion timestamps (not yet implemented)"))
             .with_input()
             .with_output()
             .with_format()
             .with_ion_version()
     }
 
-    fn run(&self, command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
+    fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
         // Because JSON data is valid Ion, the `cat` command may be reused for converting JSON.
         // TODO ideally, this would perform some smarter "up-conversion".
-        CatCommand.run(command_path, args)
+        let detect_timestamps = args.get_flag("detect-timestamps");
+        
+        CommandIo::new(args)?.for_each_input(|output, input| {
+            let input_name = input.name().to_owned();
+            let reader = input.into_source();
+            convert(reader, output, detect_timestamps, &input_name)
+        })
     }
+}
+
+pub fn convert(
+    reader: impl std::io::Read,
+    output: &mut CommandOutput,
+    detect_timestamps: bool,
+    input_name: &str,
+) -> Result<()> {
+    const FLUSH_EVERY_N: usize = 100;
+    let mut value_count = 0usize;
+    let mut writer = output.as_writer()?;
+
+    // Streaming deserializer to handle large JSON files
+    let deserializer = Deserializer::from_reader(reader);
+
+    for json_value in deserializer.into_iter::<Value>() {
+        let json_value = json_value
+            .with_context(|| format!("Input file '{}' contains invalid JSON.", input_name))?;
+        let ion_element = to_ion_element(json_value, detect_timestamps)?;
+        writer.write(&ion_element)?;
+        value_count += 1;
+
+        // Periodic flushing
+        if value_count % FLUSH_EVERY_N == 0 {
+            writer.flush()?;
+        }
+    }
+
+    writer.close()?;
+    Ok(())
+}
+
+fn to_ion_element(value: Value, detect_timestamps: bool) -> Result<Element> {
+    Ok(match value {
+        Value::Null => Element::null(ion_rs::IonType::Null),
+        Value::Bool(b) => Element::from(b),
+        Value::Number(n) => {
+            // Preserve integer precision when possible
+            // fall back to float
+            if let Some(i) = n.as_i64() {
+                Element::from(i)
+            } else {
+                Element::from(n.as_f64().unwrap())
+            }
+        }
+        Value::String(s) => {
+            if detect_timestamps && is_timestamp_like(&s) {
+                // Fall back if timestamp parsing fails
+                if let Ok(timestamp) = parse_timestamp(&s) {
+                    return Ok(Element::from(timestamp));
+                }
+            }
+            Element::from(s)
+        }
+        Value::Array(arr) => {
+            let elements: Result<Vec<Element>> = arr.into_iter()
+                .map(|v| to_ion_element(v, detect_timestamps))
+                .collect();
+            Element::from(ion_rs::List::from(elements?))
+        }
+        Value::Object(obj) => {
+            let mut struct_builder = ion_rs::Struct::builder();
+            for (key, val) in obj {
+                struct_builder = struct_builder.with_field(key, to_ion_element(val, detect_timestamps)?);
+            }
+            Element::from(struct_builder.build())
+        }
+    })
+}
+
+fn parse_timestamp(s: &str) -> Result<Timestamp> {
+    let Some((date_part, time_part)) = s.split_once('T') else {
+        return Err(anyhow::anyhow!("Not a valid ISO 8601 datetime format"));
+    };
+
+    let date_parts: Vec<&str> = date_part.split('-').collect();
+    if date_parts.len() != 3 {
+        return Err(anyhow::anyhow!("Invalid date format"));
+    }
+
+    let year: u32 = date_parts[0].parse()?;
+    let month: u32 = date_parts[1].parse()?;
+    let day: u32 = date_parts[2].parse()?;
+
+    let time_clean = time_part.trim_end_matches('Z');
+    let time_str = if let Some(pos) = time_clean.find('+') {
+        &time_clean[..pos]
+    } else if let Some(pos) = time_clean.rfind('-').filter(|&i| i > 2) {
+        &time_clean[..pos]
+    } else {
+        time_clean
+    };
+
+    let time_parts: Vec<&str> = time_str.split(':').collect();
+    if time_parts.len() < 2 {
+        return Err(anyhow::anyhow!("Invalid time format"));
+    }
+
+    let hour: u32 = time_parts[0].parse()?;
+    let minute: u32 = time_parts[1].parse()?;
+    let second: u32 = if time_parts.len() > 2 {
+        time_parts[2].split('.').next().unwrap_or("0").parse().unwrap_or(0)
+    } else {
+        0
+    };
+
+    // Building the Ion timestamp using builder patterns
+    Timestamp::with_year(year)
+        .with_month(month)
+        .with_day(day)
+        .with_hour_and_minute(hour, minute)
+        .with_second(second)
+        .build()
+        .map_err(Into::into)
+}
+
+fn is_timestamp_like(s: &str) -> bool {
+    // Heuristic to avoid parsing on non-timestamp strings
+    s.len() >= 19 && s.contains('T') && s.matches('-').count() >= 2 && s.contains(':')
 }

--- a/src/bin/ion/commands/from/json.rs
+++ b/src/bin/ion/commands/from/json.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use clap::{arg, ArgMatches, Command};
-use ion_rs::{Element, Timestamp};
+use ion_rs::Element;
 use serde_json::{Deserializer, Value};
 
 use crate::commands::{CommandIo, IonCliCommand, WithIonCliArgument};
@@ -26,9 +26,8 @@ impl IonCliCommand for FromJsonCommand {
     }
 
     fn configure_args(&self, command: Command) -> Command {
-        // Args must be identical to CatCommand so that we can safely delegate
         command
-            .arg(arg!(--"detect-timestamps" "Parse ISO 8601 timestamp strings as Ion timestamps (not yet implemented)"))
+            .arg(arg!(--"detect-timestamps" "Parse ISO 8601 timestamp strings as Ion timestamps"))
             .with_input()
             .with_output()
             .with_format()
@@ -39,11 +38,9 @@ impl IonCliCommand for FromJsonCommand {
         // Because JSON data is valid Ion, the `cat` command may be reused for converting JSON.
         // TODO ideally, this would perform some smarter "up-conversion".
         let detect_timestamps = args.get_flag("detect-timestamps");
-
         CommandIo::new(args)?.for_each_input(|output, input| {
             let input_name = input.name().to_owned();
-            let reader = input.into_source();
-            convert(reader, output, detect_timestamps, &input_name)
+            convert(input.into_source(), output, detect_timestamps, &input_name)
         })
     }
 }
@@ -54,28 +51,22 @@ pub fn convert(
     detect_timestamps: bool,
     input_name: &str,
 ) -> Result<()> {
-    const FLUSH_EVERY_N: usize = 100;
-    let mut value_count = 0usize;
     let mut writer = output.as_writer()?;
 
     // Streaming deserializer to handle large JSON files
     let deserializer = Deserializer::from_reader(reader);
 
-    for json_value in deserializer.into_iter::<Value>() {
+    for (i, json_value) in deserializer.into_iter::<Value>().enumerate() {
         let json_value = json_value
             .with_context(|| format!("Input file '{}' contains invalid JSON.", input_name))?;
-        let ion_element = to_ion_element(json_value, detect_timestamps)?;
-        writer.write(&ion_element)?;
-        value_count += 1;
-
+        writer.write(&to_ion_element(json_value, detect_timestamps)?)?;
         // Periodic flushing
-        if value_count % FLUSH_EVERY_N == 0 {
+        if i % 100 == 99 {
             writer.flush()?;
         }
     }
 
-    writer.close()?;
-    Ok(())
+    writer.close().map_err(Into::into)
 }
 
 fn to_ion_element(value: Value, detect_timestamps: bool) -> Result<Element> {
@@ -93,15 +84,16 @@ fn to_ion_element(value: Value, detect_timestamps: bool) -> Result<Element> {
         }
         Value::String(s) => {
             if detect_timestamps && is_timestamp_like(&s) {
-                // Fall back if timestamp parsing fails
-                if let Ok(timestamp) = parse_timestamp(&s) {
-                    return Ok(Element::from(timestamp));
+                if let Ok(element) = Element::read_one(s.as_bytes()) {
+                    if element.ion_type() == ion_rs::IonType::Timestamp {
+                        return Ok(element);
+                    }
                 }
             }
             Element::from(s)
         }
         Value::Array(arr) => {
-            let elements: Result<Vec<Element>> = arr
+            let elements: Result<Vec<_>> = arr
                 .into_iter()
                 .map(|v| to_ion_element(v, detect_timestamps))
                 .collect();
@@ -118,58 +110,9 @@ fn to_ion_element(value: Value, detect_timestamps: bool) -> Result<Element> {
     })
 }
 
-fn parse_timestamp(s: &str) -> Result<Timestamp> {
-    let Some((date_part, time_part)) = s.split_once('T') else {
-        return Err(anyhow::anyhow!("Not a valid ISO 8601 datetime format"));
-    };
-
-    let date_parts: Vec<&str> = date_part.split('-').collect();
-    if date_parts.len() != 3 {
-        return Err(anyhow::anyhow!("Invalid date format"));
-    }
-
-    let year: u32 = date_parts[0].parse()?;
-    let month: u32 = date_parts[1].parse()?;
-    let day: u32 = date_parts[2].parse()?;
-
-    let time_clean = time_part.trim_end_matches('Z');
-    let time_str = if let Some(pos) = time_clean.find('+') {
-        &time_clean[..pos]
-    } else if let Some(pos) = time_clean.rfind('-').filter(|&i| i > 2) {
-        &time_clean[..pos]
-    } else {
-        time_clean
-    };
-
-    let time_parts: Vec<&str> = time_str.split(':').collect();
-    if time_parts.len() < 2 {
-        return Err(anyhow::anyhow!("Invalid time format"));
-    }
-
-    let hour: u32 = time_parts[0].parse()?;
-    let minute: u32 = time_parts[1].parse()?;
-    let second: u32 = if time_parts.len() > 2 {
-        time_parts[2]
-            .split('.')
-            .next()
-            .unwrap_or("0")
-            .parse()
-            .unwrap_or(0)
-    } else {
-        0
-    };
-
-    // Building the Ion timestamp using builder patterns
-    Timestamp::with_year(year)
-        .with_month(month)
-        .with_day(day)
-        .with_hour_and_minute(hour, minute)
-        .with_second(second)
-        .build()
-        .map_err(Into::into)
-}
-
 fn is_timestamp_like(s: &str) -> bool {
-    // Heuristic to avoid parsing on non-timestamp strings
-    s.len() >= 19 && s.contains('T') && s.matches('-').count() >= 2 && s.contains(':')
+    s.len() >= 4 
+        && s[..4].chars().all(|c| c.is_ascii_digit())
+        && (s.contains('T') || (s.len() == 10 && s.matches('-').count() == 2))
+        && !(s.len() == 4 && s.chars().all(|c| c.is_ascii_digit()))
 }

--- a/src/bin/ion/commands/from/json.rs
+++ b/src/bin/ion/commands/from/json.rs
@@ -40,11 +40,14 @@ impl IonCliCommand for FromJsonCommand {
 
         CommandIo::new(args)?.for_each_input(|output, input| {
             let mut reader = Reader::new(AnyEncoding, input.into_source())?;
-            let encoding = *output.encoding();
-            let format = *output.format();
-            let mapper =
-                detect_timestamps.then_some(convert_timestamps as fn(Element) -> Result<Element>);
-            write_all_as(&mut reader, output, encoding, format, mapper)?;
+            let mapper = detect_timestamps.then_some(convert_timestamps);
+            write_all_as(
+                &mut reader,
+                output,
+                *output.encoding(),
+                *output.format(),
+                mapper,
+            )?;
             Ok(())
         })
     }

--- a/src/bin/ion/commands/from/json.rs
+++ b/src/bin/ion/commands/from/json.rs
@@ -41,13 +41,8 @@ impl IonCliCommand for FromJsonCommand {
         CommandIo::new(args)?.for_each_input(|output, input| {
             let mut reader = Reader::new(AnyEncoding, input.into_source())?;
             let mapper = detect_timestamps.then_some(convert_timestamps);
-            write_all_as(
-                &mut reader,
-                output,
-                *output.encoding(),
-                *output.format(),
-                mapper,
-            )?;
+            let (encoding, format) = (*output.encoding(), *output.format());
+            write_all_as(&mut reader, output, encoding, format, mapper)?;
             Ok(())
         })
     }

--- a/src/bin/ion/commands/from/json.rs
+++ b/src/bin/ion/commands/from/json.rs
@@ -54,14 +54,16 @@ pub fn convert(
     let mut value_count = 0usize;
     let mut ion_reader = Reader::new(AnyEncoding, input.into_source())?;
 
+    let mapper = if detect_timestamps {
+        convert_timestamps
+    } else {
+        |element| Ok(element) // Identity mapper
+    };
+
     while let Some(lazy_value) = ion_reader.next()? {
         let value_ref = lazy_value.read()?;
         let element = Element::try_from(value_ref)?;
-        let converted_element = if detect_timestamps {
-            convert_timestamps(element)?
-        } else {
-            element
-        };
+        let converted_element = mapper(element)?;
         writer.write(&converted_element)?;
         value_count += 1;
         if value_count % FLUSH_EVERY_N == 0 {

--- a/src/bin/ion/commands/from/json.rs
+++ b/src/bin/ion/commands/from/json.rs
@@ -54,16 +54,16 @@ pub fn convert(
     let mut value_count = 0usize;
     let mut ion_reader = Reader::new(AnyEncoding, input.into_source())?;
 
-    let mapper = if detect_timestamps {
-        convert_timestamps
-    } else {
-        |element| Ok(element) // Identity mapper
-    };
-
     while let Some(lazy_value) = ion_reader.next()? {
         let value_ref = lazy_value.read()?;
         let element = Element::try_from(value_ref)?;
-        let converted_element = mapper(element)?;
+
+        let converted_element = if detect_timestamps {
+            convert_timestamps(element)?
+        } else {
+            element
+        };
+
         writer.write(&converted_element)?;
         value_count += 1;
         if value_count % FLUSH_EVERY_N == 0 {

--- a/src/bin/ion/commands/from/json.rs
+++ b/src/bin/ion/commands/from/json.rs
@@ -36,7 +36,6 @@ impl IonCliCommand for FromJsonCommand {
 
     fn run(&self, _command_path: &mut Vec<String>, args: &ArgMatches) -> Result<()> {
         // Because JSON data is valid Ion, the `cat` command may be reused for converting JSON.
-        // TODO ideally, this would perform some smarter "up-conversion".
         let detect_timestamps = args.get_flag("detect-timestamps");
 
         CommandIo::new(args)?.for_each_input(|output, input| {

--- a/src/bin/ion/commands/head.rs
+++ b/src/bin/ion/commands/head.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::{value_parser, Arg, ArgMatches, Command};
-use ion_rs::{AnyEncoding, Reader};
+use ion_rs::{AnyEncoding, Element, Reader};
 
 use crate::commands::{CommandIo, IonCliCommand, WithIonCliArgument};
 use crate::transcribe::write_n_as;
@@ -53,7 +53,14 @@ impl IonCliCommand for HeadCommand {
             let mut reader = Reader::new(AnyEncoding, input.into_source())?;
             let encoding = *output.encoding();
             let format = *output.format();
-            write_n_as(&mut reader, output, encoding, format, num_values, |e| Ok(e))?;
+            write_n_as(
+                &mut reader,
+                output,
+                encoding,
+                format,
+                num_values,
+                None::<fn(Element) -> Result<Element>>,
+            )?;
             Ok(())
         })
     }

--- a/src/bin/ion/commands/head.rs
+++ b/src/bin/ion/commands/head.rs
@@ -52,14 +52,8 @@ impl IonCliCommand for HeadCommand {
         let transform = None::<fn(Element) -> Result<Element>>;
         CommandIo::new(args)?.for_each_input(|output, input| {
             let mut reader = Reader::new(AnyEncoding, input.into_source())?;
-            write_n_as(
-                &mut reader,
-                output,
-                *output.encoding(),
-                *output.format(),
-                num_values,
-                transform,
-            )?;
+            let (encoding, format) = (*output.encoding(), *output.format());
+            write_n_as(&mut reader, output, encoding, format, num_values, transform)?;
             Ok(())
         })
     }

--- a/src/bin/ion/commands/head.rs
+++ b/src/bin/ion/commands/head.rs
@@ -49,12 +49,17 @@ impl IonCliCommand for HeadCommand {
 
         let num_values = *args.get_one::<usize>("values").unwrap();
 
+        let transform = None::<fn(Element) -> Result<Element>>;
         CommandIo::new(args)?.for_each_input(|output, input| {
             let mut reader = Reader::new(AnyEncoding, input.into_source())?;
-            let encoding = *output.encoding();
-            let format = *output.format();
-            let transform = None::<fn(Element) -> Result<Element>>;
-            write_n_as(&mut reader, output, encoding, format, num_values, transform)?;
+            write_n_as(
+                &mut reader,
+                output,
+                *output.encoding(),
+                *output.format(),
+                num_values,
+                transform,
+            )?;
             Ok(())
         })
     }

--- a/src/bin/ion/commands/head.rs
+++ b/src/bin/ion/commands/head.rs
@@ -53,7 +53,7 @@ impl IonCliCommand for HeadCommand {
             let mut reader = Reader::new(AnyEncoding, input.into_source())?;
             let encoding = *output.encoding();
             let format = *output.format();
-            write_n_as(&mut reader, output, encoding, format, num_values)?;
+            write_n_as(&mut reader, output, encoding, format, num_values, |e| Ok(e))?;
             Ok(())
         })
     }

--- a/src/bin/ion/commands/head.rs
+++ b/src/bin/ion/commands/head.rs
@@ -53,14 +53,8 @@ impl IonCliCommand for HeadCommand {
             let mut reader = Reader::new(AnyEncoding, input.into_source())?;
             let encoding = *output.encoding();
             let format = *output.format();
-            write_n_as(
-                &mut reader,
-                output,
-                encoding,
-                format,
-                num_values,
-                None::<fn(Element) -> Result<Element>>,
-            )?;
+            let transform = None::<fn(Element) -> Result<Element>>;
+            write_n_as(&mut reader, output, encoding, format, num_values, transform)?;
             Ok(())
         })
     }

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -24,6 +24,7 @@ pub mod jq;
 pub mod primitive;
 pub mod schema;
 pub mod stats;
+pub mod structural_recursion;
 pub mod symtab;
 pub mod timestamp_conversion;
 pub mod to;

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -25,6 +25,7 @@ pub mod primitive;
 pub mod schema;
 pub mod stats;
 pub mod symtab;
+pub mod timestamp_conversion;
 pub mod to;
 
 pub(crate) use command_namespace::IonCliNamespace;

--- a/src/bin/ion/commands/structural_recursion.rs
+++ b/src/bin/ion/commands/structural_recursion.rs
@@ -1,0 +1,120 @@
+use anyhow::Result;
+use ion_rs::{AnyEncoding, Element, IonType, LazyValue, ValueRef};
+
+/// Trait for operations that transform Ion elements,
+/// used for transformations like timestamp conversions
+pub trait ElementMapper {
+    fn map(&self, element: Element) -> Result<Element>;
+}
+
+/// Trait for operations that analyze Ion values without transformation,
+/// used for analysis like depth calculation that only need to examine values
+pub trait ValueVisitor<T> {
+    fn visit(&mut self, value: ValueRef<AnyEncoding>, depth: usize) -> Result<()>;
+    fn result(self) -> T;
+}
+
+/// Iteratively applies a mapper to all elements in an Ion structure
+/// This function uses an explicit work stack instead of recursion
+/// It processes the structure in post-order (children before parents) to enable reconstruction
+pub fn map_structure<M: ElementMapper>(root: Element, mapper: &M) -> Result<Element> {
+    enum WorkItem {
+        Process(Element), // Process a single element (apply mapper or recurse into children)
+        BuildList(usize),
+        BuildStruct(Vec<String>),
+    }
+
+    let mut stack = vec![WorkItem::Process(root)];
+    let mut results = Vec::new(); // Store processed elements in post-order
+
+    while let Some(item) = stack.pop() {
+        match item {
+            WorkItem::Process(element) => {
+                match element.ion_type() {
+                    IonType::List => {
+                        // For lists, collect all elements, then push reconstruction work
+                        let list = element.as_sequence().unwrap();
+                        let elements: Vec<_> = list.elements().cloned().collect();
+                        stack.push(WorkItem::BuildList(elements.len()));
+                        for elem in elements.into_iter().rev() {
+                            stack.push(WorkItem::Process(elem));
+                        }
+                    }
+                    IonType::Struct => {
+                        // For structs, collect field names & values, then push reconstruction work
+                        let struct_val = element.as_struct().unwrap();
+                        let fields: Vec<_> = struct_val.fields().collect();
+                        let field_names: Vec<_> = fields
+                            .iter()
+                            .map(|(k, _)| k.text().unwrap().to_string())
+                            .collect();
+                        stack.push(WorkItem::BuildStruct(field_names));
+                        for (_, value) in fields.into_iter().rev() {
+                            stack.push(WorkItem::Process(value.clone()));
+                        }
+                    }
+                    _ => {
+                        let mapped = mapper.map(element)?;
+                        results.push(mapped);
+                    }
+                }
+            }
+            WorkItem::BuildList(size) => {
+                let elements = results.split_off(results.len() - size);
+                results.push(Element::from(ion_rs::List::from(elements)));
+            }
+            WorkItem::BuildStruct(field_names) => {
+                // Take the last `field_names.len()` elements & build a struct
+                let values = results.split_off(results.len() - field_names.len());
+                let mut struct_builder = ion_rs::Struct::builder();
+                for (name, value) in field_names.into_iter().zip(values) {
+                    struct_builder = struct_builder.with_field(name, value);
+                }
+                results.push(Element::from(struct_builder.build()));
+            }
+        }
+    }
+
+    Ok(results
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| Element::null(IonType::Null)))
+}
+
+/// Iteratively visits all values in an Ion structure for analysis
+/// This function performs a depth-first traversal without reconstruction
+pub fn visit_structure<V: ValueVisitor<T>, T>(
+    root: LazyValue<AnyEncoding>,
+    mut visitor: V,
+) -> Result<T> {
+    let mut stack = vec![(root, 0)];
+
+    while let Some((current_value, depth)) = stack.pop() {
+        let value_ref = current_value.read()?;
+        visitor.visit(value_ref, depth)?;
+
+        // For container types, add children to the stack with incremented depth
+        match value_ref {
+            ValueRef::Struct(s) => {
+                for field in s {
+                    stack.push((field?.value(), depth + 1));
+                }
+            }
+            ValueRef::List(s) => {
+                // Add all list elements to stack
+                for element in s {
+                    stack.push((element?, depth + 1));
+                }
+            }
+            ValueRef::SExp(s) => {
+                // Add all s-expression elements to stack
+                for element in s {
+                    stack.push((element?, depth + 1));
+                }
+            }
+            _ => continue,
+        }
+    }
+
+    Ok(visitor.result())
+}

--- a/src/bin/ion/commands/timestamp_conversion.rs
+++ b/src/bin/ion/commands/timestamp_conversion.rs
@@ -1,0 +1,73 @@
+use anyhow::Result;
+use ion_rs::{Element, IonType};
+
+/// Recursively converts timestamp-like strings to Ion timestamps in the given element.
+pub fn convert_timestamps(element: Element) -> Result<Element> {
+    Ok(match element.ion_type() {
+        IonType::String => {
+            let s = element.as_string().unwrap();
+            if is_timestamp_like(s) {
+                if let Ok(timestamp_element) = Element::read_one(s.as_bytes()) {
+                    if timestamp_element.ion_type() == IonType::Timestamp {
+                        return Ok(timestamp_element);
+                    }
+                }
+            }
+            element
+        }
+        IonType::List => {
+            let list = element.as_sequence().unwrap();
+            let converted: Result<Vec<_>> = list
+                .elements()
+                .map(|e| convert_timestamps(e.clone()))
+                .collect();
+            Element::from(ion_rs::List::from(converted?))
+        }
+        IonType::Struct => {
+            let struct_val = element.as_struct().unwrap();
+            let mut struct_builder = ion_rs::Struct::builder();
+            for (field, value) in struct_val.fields() {
+                struct_builder =
+                    struct_builder.with_field(field, convert_timestamps(value.clone())?);
+            }
+            Element::from(struct_builder.build())
+        }
+        _ => element,
+    })
+}
+
+/// Heuristic to identify strings that could be Ion timestamps
+///
+/// Ion timestamps follow ISO 8601 format with these constraints:
+/// - Years 0001-9999 (4 digits)
+/// - Precision up to nanoseconds
+/// - Must have date component (YYYY, YYYY-MM, or YYYY-MM-DD)
+///
+/// This function uses position-based checks, which are cheaper compared to string operations:
+/// - Length bounds (4-35 chars for timestamp range)
+/// - Direct character position checks
+fn is_timestamp_like(s: &str) -> bool {
+    let len = s.len();
+
+    // Bounds check, timestamps are 4-35 chars
+    if !(4..=35).contains(&len) {
+        return false;
+    }
+
+    // Must start with 4 digits
+    let bytes = s.as_bytes();
+    if !bytes[0].is_ascii_digit()
+        || !bytes[1].is_ascii_digit()
+        || !bytes[2].is_ascii_digit()
+        || !bytes[3].is_ascii_digit()
+    {
+        return false;
+    }
+
+    match len {
+        4 => false,
+        5..=9 => bytes[len - 1] == b'T',
+        10 => bytes[4] == b'-' && bytes[7] == b'-',
+        _ => len > 10 && bytes[10] == b'T',
+    }
+}

--- a/src/bin/ion/commands/timestamp_conversion.rs
+++ b/src/bin/ion/commands/timestamp_conversion.rs
@@ -31,10 +31,11 @@ pub fn convert_timestamps(element: Element) -> Result<Element> {
 
 /// Heuristic to identify strings that could be Ion timestamps
 ///
-/// Ion timestamps follow ISO 8601 format with these constraints:
-/// - Years 0001-9999 (4 digits)
-/// - Precision up to nanoseconds
+/// Ion timestamps follow W3C date/time format with these constraints:
 /// - Must have date component (YYYY, YYYY-MM, or YYYY-MM-DD)
+/// - Precision up to fractional seconds (unlimited precision)
+/// - Must end with 'T' if time components are present
+/// - Time zone offset required for timestamps with time, not allowed for date-only values
 ///
 /// This function uses position-based checks, which are cheaper compared to string operations:
 /// - Length bounds (4-35 chars for timestamp range)

--- a/src/bin/ion/commands/to/json.rs
+++ b/src/bin/ion/commands/to/json.rs
@@ -22,7 +22,7 @@ impl IonCliCommand for ToJsonCommand {
     }
 
     fn is_stable(&self) -> bool {
-        false
+        true
     }
 
     fn is_porcelain(&self) -> bool {

--- a/src/bin/ion/commands/to/json.rs
+++ b/src/bin/ion/commands/to/json.rs
@@ -83,7 +83,7 @@ fn to_json_value(value: LazyValue<AnyEncoding>) -> Result<JsonValue> {
                     .with_context(|| format!("{d} could not be turned into a Number"))?,
             )
         }
-        Timestamp(t) => JsonValue::String(t.to_string()),
+        Timestamp(t) => JsonValue::String(t.to_string()), // Note: normalizes 'Z' to '+00:00' format
         Symbol(s) => s
             .text()
             .map(|text| JsonValue::String(text.to_owned()))

--- a/src/bin/ion/transcribe.rs
+++ b/src/bin/ion/transcribe.rs
@@ -3,6 +3,18 @@ use ion_rs::*;
 use std::io::Write;
 
 /// Constructs the appropriate writer for the given format, then writes all values from the
+/// `Reader` to the new `Writer`, applying an optional mapping function to each element.
+pub(crate) fn write_all_as_with_mapper<I: IonInput>(
+    reader: &mut Reader<AnyEncoding, I>,
+    output: &mut impl Write,
+    encoding: IonEncoding,
+    format: Format,
+    mapper: Option<fn(Element) -> Result<Element>>,
+) -> Result<usize> {
+    write_n_as_with_mapper(reader, output, encoding, format, usize::MAX, mapper)
+}
+
+/// Constructs the appropriate writer for the given format, then writes all values from the
 /// `Reader` to the new `Writer`.
 pub(crate) fn write_all_as<I: IonInput>(
     reader: &mut Reader<AnyEncoding, I>,
@@ -44,6 +56,38 @@ pub(crate) fn write_n_as<I: IonInput>(
     Ok(written)
 }
 
+/// Constructs the appropriate writer for the given format, then writes up to `count` values from the
+/// `Reader` to the new `Writer`, applying an optional mapping function to each element.
+pub(crate) fn write_n_as_with_mapper<I: IonInput>(
+    reader: &mut Reader<AnyEncoding, I>,
+    output: &mut impl Write,
+    encoding: IonEncoding,
+    format: Format,
+    count: usize,
+    mapper: Option<fn(Element) -> Result<Element>>,
+) -> Result<usize> {
+    let written = match (encoding, format) {
+        (IonEncoding::Text_1_0, Format::Text(text_format)) => {
+            let mut writer = Writer::new(v1_0::Text.with_format(text_format), output)?;
+            transcribe_n_with_mapper(reader, &mut writer, count, mapper)
+        }
+        (IonEncoding::Text_1_1, Format::Text(text_format)) => {
+            let mut writer = Writer::new(v1_1::Text.with_format(text_format), output)?;
+            transcribe_n_with_mapper(reader, &mut writer, count, mapper)
+        }
+        (IonEncoding::Binary_1_0, Format::Binary) => {
+            let mut writer = Writer::new(v1_0::Binary, output)?;
+            transcribe_n_with_mapper(reader, &mut writer, count, mapper)
+        }
+        (IonEncoding::Binary_1_1, Format::Binary) => {
+            let mut writer = Writer::new(v1_1::Binary, output)?;
+            transcribe_n_with_mapper(reader, &mut writer, count, mapper)
+        }
+        unrecognized => bail!("unsupported format '{:?}'", unrecognized),
+    }?;
+    Ok(written)
+}
+
 /// Writes up to `count` values from the `Reader` to the provided `Writer`.
 fn transcribe_n(
     reader: &mut Reader<impl Decoder, impl IonInput>,
@@ -54,12 +98,52 @@ fn transcribe_n(
     let mut values_since_flush: usize = 0;
     let mut index: usize = 0;
 
-    while let Some(value) = reader.next()? {
+    while let Some(lazy_value) = reader.next()? {
         if index >= count {
             break;
         }
 
-        writer.write(value)?;
+        writer.write(lazy_value)?;
+
+        index += 1;
+        values_since_flush += 1;
+        if values_since_flush == FLUSH_EVERY_N {
+            writer.flush()?;
+            values_since_flush = 0;
+        }
+    }
+
+    writer.flush()?;
+    Ok(index)
+}
+
+/// Writes up to `count` values from the `Reader` to the provided `Writer`,
+/// applying an optional mapping function to each element.
+fn transcribe_n_with_mapper(
+    reader: &mut Reader<impl Decoder, impl IonInput>,
+    writer: &mut Writer<impl Encoding, impl Write>,
+    count: usize,
+    mapper: Option<fn(Element) -> Result<Element>>,
+) -> Result<usize> {
+    const FLUSH_EVERY_N: usize = 100;
+    let mut values_since_flush: usize = 0;
+    let mut index: usize = 0;
+
+    while let Some(lazy_value) = reader.next()? {
+        if index >= count {
+            break;
+        }
+
+        match mapper {
+            Some(map_fn) => {
+                let element = Element::try_from(lazy_value.read()?)?;
+                let transformed_element = map_fn(element)?;
+                writer.write(&transformed_element)?;
+            }
+            None => {
+                writer.write(lazy_value)?;
+            }
+        }
 
         index += 1;
         values_since_flush += 1;

--- a/src/bin/ion/transcribe.rs
+++ b/src/bin/ion/transcribe.rs
@@ -3,127 +3,56 @@ use ion_rs::*;
 use std::io::Write;
 
 /// Constructs the appropriate writer for the given format, then writes all values from the
-/// `Reader` to the new `Writer`, applying an optional mapping function to each element.
-pub(crate) fn write_all_as_with_mapper<I: IonInput>(
+/// `Reader` to the new `Writer`, applying a mapping function to each element.
+pub(crate) fn write_all_as<I: IonInput, M: Fn(Element) -> Result<Element>>(
     reader: &mut Reader<AnyEncoding, I>,
     output: &mut impl Write,
     encoding: IonEncoding,
     format: Format,
-    mapper: Option<fn(Element) -> Result<Element>>,
+    mapper: M,
 ) -> Result<usize> {
-    write_n_as_with_mapper(reader, output, encoding, format, usize::MAX, mapper)
-}
-
-/// Constructs the appropriate writer for the given format, then writes all values from the
-/// `Reader` to the new `Writer`.
-pub(crate) fn write_all_as<I: IonInput>(
-    reader: &mut Reader<AnyEncoding, I>,
-    output: &mut impl Write,
-    encoding: IonEncoding,
-    format: Format,
-) -> Result<usize> {
-    write_n_as(reader, output, encoding, format, usize::MAX)
+    write_n_as(reader, output, encoding, format, usize::MAX, mapper)
 }
 
 /// Constructs the appropriate writer for the given format, then writes up to `count` values from the
-/// `Reader` to the new `Writer`.
-pub(crate) fn write_n_as<I: IonInput>(
+/// `Reader` to the new `Writer`, applying a mapping function to each element.
+pub(crate) fn write_n_as<I: IonInput, M: Fn(Element) -> Result<Element>>(
     reader: &mut Reader<AnyEncoding, I>,
     output: &mut impl Write,
     encoding: IonEncoding,
     format: Format,
     count: usize,
+    mapper: M,
 ) -> Result<usize> {
     let written = match (encoding, format) {
         (IonEncoding::Text_1_0, Format::Text(text_format)) => {
             let mut writer = Writer::new(v1_0::Text.with_format(text_format), output)?;
-            transcribe_n(reader, &mut writer, count)
+            transcribe_n(&mut writer, reader, count, mapper)
         }
         (IonEncoding::Text_1_1, Format::Text(text_format)) => {
             let mut writer = Writer::new(v1_1::Text.with_format(text_format), output)?;
-            transcribe_n(reader, &mut writer, count)
+            transcribe_n(&mut writer, reader, count, mapper)
         }
         (IonEncoding::Binary_1_0, Format::Binary) => {
             let mut writer = Writer::new(v1_0::Binary, output)?;
-            transcribe_n(reader, &mut writer, count)
+            transcribe_n(&mut writer, reader, count, mapper)
         }
         (IonEncoding::Binary_1_1, Format::Binary) => {
             let mut writer = Writer::new(v1_1::Binary, output)?;
-            transcribe_n(reader, &mut writer, count)
+            transcribe_n(&mut writer, reader, count, mapper)
         }
         unrecognized => bail!("unsupported format '{:?}'", unrecognized),
     }?;
     Ok(written)
-}
-
-/// Constructs the appropriate writer for the given format, then writes up to `count` values from the
-/// `Reader` to the new `Writer`, applying an optional mapping function to each element.
-pub(crate) fn write_n_as_with_mapper<I: IonInput>(
-    reader: &mut Reader<AnyEncoding, I>,
-    output: &mut impl Write,
-    encoding: IonEncoding,
-    format: Format,
-    count: usize,
-    mapper: Option<fn(Element) -> Result<Element>>,
-) -> Result<usize> {
-    let written = match (encoding, format) {
-        (IonEncoding::Text_1_0, Format::Text(text_format)) => {
-            let mut writer = Writer::new(v1_0::Text.with_format(text_format), output)?;
-            transcribe_n_with_mapper(reader, &mut writer, count, mapper)
-        }
-        (IonEncoding::Text_1_1, Format::Text(text_format)) => {
-            let mut writer = Writer::new(v1_1::Text.with_format(text_format), output)?;
-            transcribe_n_with_mapper(reader, &mut writer, count, mapper)
-        }
-        (IonEncoding::Binary_1_0, Format::Binary) => {
-            let mut writer = Writer::new(v1_0::Binary, output)?;
-            transcribe_n_with_mapper(reader, &mut writer, count, mapper)
-        }
-        (IonEncoding::Binary_1_1, Format::Binary) => {
-            let mut writer = Writer::new(v1_1::Binary, output)?;
-            transcribe_n_with_mapper(reader, &mut writer, count, mapper)
-        }
-        unrecognized => bail!("unsupported format '{:?}'", unrecognized),
-    }?;
-    Ok(written)
-}
-
-/// Writes up to `count` values from the `Reader` to the provided `Writer`.
-fn transcribe_n(
-    reader: &mut Reader<impl Decoder, impl IonInput>,
-    writer: &mut Writer<impl Encoding, impl Write>,
-    count: usize,
-) -> Result<usize> {
-    const FLUSH_EVERY_N: usize = 100;
-    let mut values_since_flush: usize = 0;
-    let mut index: usize = 0;
-
-    while let Some(lazy_value) = reader.next()? {
-        if index >= count {
-            break;
-        }
-
-        writer.write(lazy_value)?;
-
-        index += 1;
-        values_since_flush += 1;
-        if values_since_flush == FLUSH_EVERY_N {
-            writer.flush()?;
-            values_since_flush = 0;
-        }
-    }
-
-    writer.flush()?;
-    Ok(index)
 }
 
 /// Writes up to `count` values from the `Reader` to the provided `Writer`,
-/// applying an optional mapping function to each element.
-fn transcribe_n_with_mapper(
-    reader: &mut Reader<impl Decoder, impl IonInput>,
+/// applying a mapping function to each element.
+fn transcribe_n<M: Fn(Element) -> Result<Element>>(
     writer: &mut Writer<impl Encoding, impl Write>,
+    reader: &mut Reader<impl Decoder, impl IonInput>,
     count: usize,
-    mapper: Option<fn(Element) -> Result<Element>>,
+    mapper: M,
 ) -> Result<usize> {
     const FLUSH_EVERY_N: usize = 100;
     let mut values_since_flush: usize = 0;
@@ -134,16 +63,9 @@ fn transcribe_n_with_mapper(
             break;
         }
 
-        match mapper {
-            Some(map_fn) => {
-                let element = Element::try_from(lazy_value.read()?)?;
-                let transformed_element = map_fn(element)?;
-                writer.write(&transformed_element)?;
-            }
-            None => {
-                writer.write(lazy_value)?;
-            }
-        }
+        let element = Element::try_from(lazy_value.read()?)?;
+        let transformed_element = mapper(element)?;
+        writer.write(&transformed_element)?;
 
         index += 1;
         values_since_flush += 1;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -224,15 +224,23 @@ mod from_json_tests {
     #[rstest]
     #[case::valid_timestamp(
         r#"{"created": "2023-12-25T10:30:00Z", "name": "test"}"#,
-        r#"{created: 2023-12-25T10:30:00-00:00, name: "test"}"#
+        r#"{created: 2023-12-25T10:30:00+00:00, name: "test"}"#
     )]
     #[case::timestamp_with_milliseconds(
         r#"{"timestamp": "2023-01-01T12:00:00.123Z"}"#,
-        r#"{timestamp: 2023-01-01T12:00:00-00:00}"#
+        r#"{timestamp: 2023-01-01T12:00:00.123+00:00}"#
     )]
     #[case::timestamp_with_timezone(
         r#"{"date": "2023-06-15T14:30:45+05:00"}"#,
-        r#"{date: 2023-06-15T14:30:45-00:00}"#
+        r#"{date: 2023-06-15T14:30:45+05:00}"#
+    )]
+    #[case::date_only(
+        r#"{"birthday": "2023-12-25"}"#,
+        r#"{birthday: 2023-12-25}"#
+    )]
+    #[case::microsecond_precision(
+        r#"{"precise": "2023-01-01T12:00:00.123456Z"}"#,
+        r#"{precise: 2023-01-01T12:00:00.123456+00:00}"#
     )]
     /// Tests JSON to Ion conversion with timestamp detection enabled
     fn test_from_json_with_timestamp_detection(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -317,10 +317,10 @@ mod timestamp_roundtrip_tests {
         cmd.args(["cat", flag, "--format", "pretty"])
             .timeout(Duration::new(5, 0))
             .write_stdin(input_ion.as_bytes());
-        
+
         let output = cmd.assert().success().get_output().stdout.clone();
         let result_element = Element::read_one(&output)?;
-        
+
         // Should convert string to timestamp
         let expected = Element::read_one(r#"{created: 2025-01-01T10:30:00+00:00}"#.as_bytes())?;
         assert_eq!(expected, result_element);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -222,33 +222,25 @@ mod timestamp_roundtrip_tests {
     use super::*;
 
     #[rstest]
-    #[case::valid_timestamp(
-        r#"{created: 2023-12-25T10:30:00Z, name: "test"}"#
-    )]
-    #[case::timestamp_with_milliseconds(
-        r#"{timestamp: 2023-01-01T12:00:00.123Z}"#
-    )]
-    #[case::timestamp_with_timezone(
-        r#"{date: 2023-06-15T14:30:45+05:00}"#
-    )]
+    #[case::valid_timestamp(r#"{created: 2023-12-25T10:30:00Z, name: "test"}"#)]
+    #[case::timestamp_with_milliseconds(r#"{timestamp: 2023-01-01T12:00:00.123Z}"#)]
+    #[case::timestamp_with_timezone(r#"{date: 2023-06-15T14:30:45+05:00}"#)]
     #[case::date_only(r#"{birthday: 2023-12-25}"#)]
-    #[case::microsecond_precision(
-        r#"{precise: 2023-01-01T12:00:00.123456Z}"#
-    )]
+    #[case::microsecond_precision(r#"{precise: 2023-01-01T12:00:00.123456Z}"#)]
     /// Tests Ion → JSON → Ion roundtrip with timestamp preservation
-    fn test_ion_json_ion_roundtrip_with_timestamps(
-        #[case] original_ion: &str,
-    ) -> Result<()> {
+    fn test_ion_json_ion_roundtrip_with_timestamps(#[case] original_ion: &str) -> Result<()> {
         // Step 1: Ion → JSON
         let mut to_json_cmd = Command::cargo_bin("ion")?;
-        to_json_cmd.args(["to", "-X", "json"])
+        to_json_cmd
+            .args(["to", "-X", "json"])
             .timeout(Duration::new(5, 0))
             .write_stdin(original_ion.as_bytes());
         let json_output = to_json_cmd.assert().success().get_output().stdout.clone();
 
         // Step 2: JSON → Ion with timestamp detection
         let mut from_json_cmd = Command::cargo_bin("ion")?;
-        from_json_cmd.args(["from", "-X", "json", "--detect-timestamps"])
+        from_json_cmd
+            .args(["from", "-X", "json", "--detect-timestamps"])
             .timeout(Duration::new(5, 0))
             .write_stdin(json_output);
         let final_output = from_json_cmd.assert().success().get_output().stdout.clone();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -227,9 +227,9 @@ mod timestamp_roundtrip_tests {
     #[case::timestamp_with_timezone(r#"{date: 2023-06-15T14:30:45+05:00}"#)]
     #[case::date_only(r#"{birthday: 2023-12-25}"#)]
     #[case::microsecond_precision(r#"{precise: 2023-01-01T12:00:00.123456Z}"#)]
-    /// Tests Ion → JSON → Ion roundtrip with timestamp preservation
+    /// Tests Ion to JSON to Ion roundtrip with timestamp preservation
     fn test_ion_json_ion_roundtrip_with_timestamps(#[case] original_ion: &str) -> Result<()> {
-        // Step 1: Ion → JSON
+        //  Ion to JSON
         let mut to_json_cmd = Command::cargo_bin("ion")?;
         to_json_cmd
             .args(["to", "-X", "json"])
@@ -237,7 +237,7 @@ mod timestamp_roundtrip_tests {
             .write_stdin(original_ion.as_bytes());
         let json_output = to_json_cmd.assert().success().get_output().stdout.clone();
 
-        // Step 2: JSON → Ion with timestamp detection
+        // JSON to Ion with timestamp detection
         let mut from_json_cmd = Command::cargo_bin("ion")?;
         from_json_cmd
             .args(["from", "-X", "json", "--detect-timestamps"])

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -278,53 +278,6 @@ mod timestamp_roundtrip_tests {
         assert_eq!(expected_element, actual_ion);
         Ok(())
     }
-
-    #[rstest]
-    #[case::valid_timestamp(r#"{created: 2025-01-01T10:30:00Z, name: "test"}"#)]
-    #[case::timestamp_with_milliseconds(r#"{timestamp: 2025-01-01T12:00:00.123Z}"#)]
-    #[case::timestamp_with_timezone(r#"{date: 2025-01-01T14:30:45+05:00}"#)]
-    /// Tests cat command preserves JSON data as-is (strings remain strings)
-    fn test_cat_timestamp_detection_roundtrip(#[case] original_ion: &str) -> Result<()> {
-        // Ion to JSON
-        let mut to_json_cmd = Command::cargo_bin("ion")?;
-        to_json_cmd
-            .args(["to", "-X", "json"])
-            .timeout(Duration::new(5, 0))
-            .write_stdin(original_ion.as_bytes());
-        let json_output = to_json_cmd.assert().success().get_output().stdout.clone();
-
-        // JSON to Ion using cat (preserves data as-is)
-        let mut cat_cmd = Command::cargo_bin("ion")?;
-        cat_cmd
-            .args(["cat", "--format", "pretty"])
-            .timeout(Duration::new(5, 0))
-            .write_stdin(json_output.clone());
-        let final_output = cat_cmd.assert().success().get_output().stdout.clone();
-
-        // Verify cat preserves JSON data as-is (timestamps become strings)
-        let final_element = Element::read_one(&final_output)?;
-        let json_element = Element::read_one(&json_output)?;
-        assert_eq!(json_element, final_element);
-        Ok(())
-    }
-
-    #[rstest]
-    #[case::cat_preserves_timestamps(r#"{created: "2025-01-01T10:30:00Z"}"#)]
-    /// Tests that cat command preserves data as-is (strings remain strings)
-    fn test_timestamp_flag_variants(#[case] input_ion: &str) -> Result<()> {
-        let mut cmd = Command::cargo_bin("ion")?;
-        cmd.args(["cat", "--format", "pretty"])
-            .timeout(Duration::new(5, 0))
-            .write_stdin(input_ion.as_bytes());
-
-        let output = cmd.assert().success().get_output().stdout.clone();
-        let result_element = Element::read_one(&output)?;
-
-        // Should preserve string as-is
-        let expected = Element::read_one(input_ion.as_bytes())?;
-        assert_eq!(expected, result_element);
-        Ok(())
-    }
 }
 
 mod code_gen_tests {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -234,10 +234,7 @@ mod from_json_tests {
         r#"{"date": "2023-06-15T14:30:45+05:00"}"#,
         r#"{date: 2023-06-15T14:30:45+05:00}"#
     )]
-    #[case::date_only(
-        r#"{"birthday": "2023-12-25"}"#,
-        r#"{birthday: 2023-12-25}"#
-    )]
+    #[case::date_only(r#"{"birthday": "2023-12-25"}"#, r#"{birthday: 2023-12-25}"#)]
     #[case::microsecond_precision(
         r#"{"precise": "2023-01-01T12:00:00.123456Z"}"#,
         r#"{precise: 2023-01-01T12:00:00.123456+00:00}"#
@@ -286,8 +283,6 @@ mod from_json_tests {
         assert_eq!(expected_element, actual_ion);
         Ok(())
     }
-
-
 }
 
 mod code_gen_tests {


### PR DESCRIPTION
### Description of changes:

Added the `--detect-timestamps`/`-t` flag to the `from json` command, which preserves the timestamp data type when converting an Ion value to JSON and back to Ion.

The timestamp detection and conversion logic is implemented in the `convert_timestamps` function, which performs two checks:

`is_timestamp_like` - A heuristic filter that quickly identifies potential timestamp strings to avoid unnecessary processing of non-timestamp values

`ion_rs::IonType::Timestamp` - Uses Ion-rust's implementation to validate and convert valid timestamp strings back to Ion timestamp types

The implementation uses an optional mapper approach in the transcribe module, where:

When `-t` flag is present: Each Ion element is processed through `convert_timestamps`

When `-t` flag is absent: Elements are written directly without materialization for optimal performance

### Example
**Input**
`
echo '{created: 2025-12-25T10:30:00Z}' | ion to json | ion from json --detect-timestamps --format pretty`

**Output**
`
{
  created: 2025-12-25T10:30:00+00:00
}
`

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
