### PR TITLE
Fix of argument parsing order issue with output flag

### DIFF
--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -146,7 +146,6 @@ impl WithIonCliArgument for ClapCommand {
     fn with_input(self) -> Self {
         self.arg(
             Arg::new("input")
-                .trailing_var_arg(true)
                 .action(ArgAction::Append)
                 .help("Input file"),
         )


### PR DESCRIPTION
### Issue #207

### Description of changes:

The `ion cat` command failed when the `-o/--output` flag was placed after input files due to `trailing_var_arg(true)` which would consume all remaining positional arguments, including the output filename when `-o` was present after the input files.

**Failing case:**
```bash
ion cat input.ion -o output.ion  # ❌ Output flag ignored
```

## Solution

Removed `.trailing_var_arg(true)` from the input argument configuration in `src/bin/ion/commands/mod.rs`.

**Edge case:**
Files starting with `-` need to follow UNIX standard handling:
```bash
ion cat -- -test.ion
```
----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
