### PR TITLE
Use GitHub runner built-in Rust support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,23 +19,10 @@ jobs:
         with:
           submodules: recursive
       - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        run: rustup toolchain install stable --profile minimal --component rustfmt
       - name: Cargo Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --workspace
+        run: cargo build --verbose --workspace
       - name: Cargo Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --workspace
+        run: cargo test --verbose --workspace
       - name: Rustfmt Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --verbose -- --check
+        run: cargo fmt --verbose -- --check


### PR DESCRIPTION
actions-rs/toolchain is unmaintained, see: https://github.com/actions-rs/toolchain/issues/216

The GitHub docs recommend using the built-in `rustup` available in GitHub runners: https://docs.github.com/en/actions/tutorials/build-and-test-code/rust

Perhaps we want to use [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) instead?

We may want to cache dependencies? See:
- https://docs.github.com/en/actions/tutorials/build-and-test-code/rust#caching-dependencies
- [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache)

This PR is meant to at least start a conversation about what we want to do with CI builds going forward. 

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
