### PR TITLE
Update ion11 branch to build with ion-rust ion11 branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,8 +1001,7 @@ dependencies = [
 [[package]]
 name = "ion-rs"
 version = "1.0.0-rc.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1635de5984b66df8c9061125d02235c7e04c575d45cd93dbd85e14e307c06695"
+source = "git+https://github.com/amazon-ion/ion-rust?branch=ion11#f433eb4fb8fe25024ce8923fcef7162f34b3a227"
 dependencies = [
  "arrayvec",
  "base64 0.12.3",
@@ -1011,7 +1010,9 @@ dependencies = [
  "compact_str",
  "delegate",
  "digest 0.9.0",
+ "generic-array",
  "ice_code",
+ "memchr",
  "num-integer",
  "num-traits",
  "phf",
@@ -1020,14 +1021,14 @@ dependencies = [
  "serde_with",
  "smallvec",
  "thiserror 1.0.69",
+ "visibility",
  "winnow",
 ]
 
 [[package]]
 name = "ion-schema"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d3f6caeca9720ae78eb68516353f6a1e2f8f589170284a03bdc355fbf5309a"
+source = "git+https://github.com/amazon-ion/ion-schema-rust?branch=ion11#9e183a5e7048ddca56ea23de9e77dc803133f629"
 dependencies = [
  "half",
  "ion-rs",
@@ -2165,6 +2166,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
+]
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,9 +2502,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.22"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ flate2 = "1.0"
 infer = "0.15.0"
 # ion-rs version must be pinned because we are using experimental features
 # See https://github.com/amazon-ion/ion-cli/issues/155
-ion-rs = { version = "1.0.0-rc.11", features = ["experimental", "experimental-ion-hash"] }
+ion-rs = { git = "https://github.com/amazon-ion/ion-rust", branch = "ion11", features = ["experimental", "experimental-ion-hash"] }
 tempfile = "3.2.0"
-ion-schema = "0.15.0"
+ion-schema = { git = "https://github.com/amazon-ion/ion-schema-rust", branch = "ion11" }
 lowcharts = "0.5.8"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = { version = "1.0.81", features = ["arbitrary_precision", "preserve_order"] }

--- a/src/bin/ion/commands/inspect.rs
+++ b/src/bin/ion/commands/inspect.rs
@@ -11,7 +11,7 @@ use crate::output::CommandOutput;
 use anyhow::{bail, Context, Result};
 use clap::builder::ValueParser;
 use clap::{Arg, ArgAction, ArgMatches, Command};
-use ion_rs::v1_0::{EncodedBinaryValue, RawValueRef};
+use ion_rs::v1_0::{BinaryValueLiteral, RawValueRef};
 use ion_rs::*;
 use termcolor::{Color, ColorSpec, WriteColor};
 
@@ -955,7 +955,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         &mut self,
         depth: usize,
         value: LazyValue<'x, AnyEncoding>,
-        encoded_value: impl EncodedBinaryValue<'x, D>,
+        encoded_value: impl BinaryValueLiteral<'x, D>,
     ) -> Result<()> {
         if !value.has_annotations() {
             return Ok(());
@@ -1036,7 +1036,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
     fn inspect_literal_container_header<'x, D: Decoder>(
         &mut self,
         depth: usize,
-        encoded_value: impl EncodedBinaryValue<'x, D>,
+        encoded_value: impl BinaryValueLiteral<'x, D>,
     ) -> Result<()> {
         let opcode_bytes: &[u8] = encoded_value.value_opcode_span().bytes();
         let mut formatter = BytesFormatter::new(
@@ -1057,7 +1057,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
     fn inspect_literal_container_footer<'x, D: Decoder>(
         &mut self,
         depth: usize,
-        encoded_value: impl EncodedBinaryValue<'x, D>,
+        encoded_value: impl BinaryValueLiteral<'x, D>,
         closing_delimiter: &str,
         trailing_delimiter: &str,
     ) -> Result<()> {
@@ -1091,7 +1091,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         depth: usize,
         delimiter: &str,
         sexp: LazySExp<'x, AnyEncoding>,
-        encoded_value: impl EncodedBinaryValue<'x, D>,
+        encoded_value: impl BinaryValueLiteral<'x, D>,
     ) -> Result<()> {
         self.inspect_literal_sequence(
             depth,
@@ -1114,7 +1114,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         closing_delimiter: &str,
         trailing_delimiter: &str,
         nested_values: impl IntoIterator<Item = IonResult<ValueExpr<'x, AnyEncoding>>>,
-        encoded_value: impl EncodedBinaryValue<'x, D>,
+        encoded_value: impl BinaryValueLiteral<'x, D>,
         value_comment_fn: impl CommentFn<'x>,
     ) -> Result<()> {
         self.inspect_literal_container_header(depth, encoded_value)?;
@@ -1305,7 +1305,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         depth: usize,
         trailing_delimiter: &str,
         struct_: LazyStruct<AnyEncoding>,
-        encoded_value: impl EncodedBinaryValue<'x, D>,
+        encoded_value: impl BinaryValueLiteral<'x, D>,
         kind: StructKind,
     ) -> Result<()> {
         self.inspect_literal_container_header(depth, encoded_value)?;
@@ -1421,7 +1421,7 @@ impl<'a, 'b> IonInspector<'a, 'b> {
         depth: usize,
         delimiter: &str,
         value: LazyValue<'x, AnyEncoding>,
-        encoded_value: impl EncodedBinaryValue<'x, D>,
+        encoded_value: impl BinaryValueLiteral<'x, D>,
         mut comment_fn: impl CommentFn<'x>,
     ) -> Result<()> {
         let range = encoded_value.value_span().range();

--- a/src/bin/ion/commands/jq.rs
+++ b/src/bin/ion/commands/jq.rs
@@ -332,9 +332,9 @@ impl Sub for JaqElement {
             // Number types, only lossless operations
             (Int(a), Int(b)) => (a + -b).into(), //TODO: use bare - with ion-rs > rc.11
             (Float(a), Float(b)) => a.sub(b).into(),
-            (Decimal(a), Decimal(b)) => a.sub(b).into(),
-            (Decimal(a), Int(b)) => a.sub(b).into(),
-            (Int(a), Decimal(b)) => a.sub(b).into(),
+            (Decimal(a), Decimal(b)) => DecimalMath::sub(a, b).into(),
+            (Decimal(a), Int(b)) => DecimalMath::sub(a, b).into(),
+            (Int(a), Decimal(b)) => DecimalMath::sub(a, b).into(),
 
             // Only try potentially lossy Float conversions when we've run out of the other options
             (a @ Int(_) | a @ Decimal(_), Float(b)) => (a.to_f64().unwrap() - b).into(),

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -240,7 +240,7 @@ pub struct CommandIo<'a> {
 }
 
 impl CommandIo<'_> {
-    fn new(args: &ArgMatches) -> Result<CommandIo> {
+    fn new(args: &ArgMatches) -> Result<CommandIo<'_>> {
         // --format pretty|text|lines|binary
         let format = args
             .try_get_one("format")

--- a/src/bin/ion/commands/timestamp_conversion.rs
+++ b/src/bin/ion/commands/timestamp_conversion.rs
@@ -7,9 +7,7 @@ struct TimestampConverter;
 
 impl ElementMapper for TimestampConverter {
     fn map(&self, element: Element) -> Result<Element> {
-        Ok(element.as_text()
-            .and_then(as_timestamp)
-            .unwrap_or(element))
+        Ok(element.as_text().and_then(as_timestamp).unwrap_or(element))
     }
 }
 
@@ -59,6 +57,7 @@ fn as_timestamp(s: &str) -> Option<Element> {
     if !is_timestamp_like(s) {
         return None;
     }
-    Element::read_one(s.as_bytes()).ok()
+    Element::read_one(s.as_bytes())
+        .ok()
         .filter(|e| e.ion_type() == IonType::Timestamp)
 }


### PR DESCRIPTION
### Issue #, if available: n/a

### Description of changes:
This PR updates the CLI's dependencies on ion-rust, and ion-schema-rust, to point to ion11 branches.

Additionally, this PR makes some other small updates:
- A type rename that occurred in ion-rust, renaming `EncodedBinaryValue` to `BinaryValueLiteral`.
- Recent changes made `DecimalMath::sub` ambiguous when calling without explicit type info, so this was made explicit.
- An elided lifetime on the return value of `CommandIo::new` was added (as an explicit infer) per clippy lint suggestion.
- A couple minor rustfmt suggestions.


----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
