### PR TITLE
Fix release-build panic in `resolve_color_choice`

### DIFF
--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -414,14 +414,18 @@ impl CommandIo<'_> {
 }
 
 fn resolve_color_choice(context_default: bool, arg_matches: &ArgMatches) -> ColorChoice {
-    if arg_matches.try_contains_id("color").is_err()
-        || arg_matches.try_contains_id("no-color").is_err()
-    {
-        // This command doesn't support the color flag.
-        return ColorChoice::Never;
-    }
-    let color = arg_matches.get_flag("color");
-    let no_color = arg_matches.get_flag("no-color");
+    // For SetTrue args, clap stores a default value, so try_get_one returns Ok(Some(&false)) when
+    // the arg is registered but not passed by the user. It returns Ok(None) when the arg was never
+    // registered (release builds) or Err (debug builds). In either unregistered case, the command
+    // doesn't support color, so we return Never.
+    let color = match arg_matches.try_get_one::<bool>("color") {
+        Ok(Some(&val)) => val,
+        _ => return ColorChoice::Never,
+    };
+    let no_color = match arg_matches.try_get_one::<bool>("no-color") {
+        Ok(Some(&val)) => val,
+        _ => return ColorChoice::Never,
+    };
     if color {
         ColorChoice::Always
     } else if no_color {
@@ -456,7 +460,6 @@ mod test {
     #[case(true, "test --no-color --color --no-color", ColorChoice::Never)]
     #[case(false, "test --color --no-color --color", ColorChoice::Always)]
     #[case(false, "test --no-color --color --no-color", ColorChoice::Never)]
-    // Tests both `with_color` and `resolve_color_choice` functions.
     fn resolve_color_choice_args(
         #[case] context_default: bool,
         #[case] args: &str,
@@ -466,5 +469,16 @@ mod test {
             .with_syntax_highlighting()
             .get_matches_from(args.split_ascii_whitespace().collect::<Vec<_>>());
         assert_eq!(resolve_color_choice(context_default, &args), expected)
+    }
+
+    #[rstest]
+    #[case(true)]
+    #[case(false)]
+    fn resolve_color_choice_without_color_args_registered(#[case] context_default: bool) {
+        let args = clap::builder::Command::new("test").get_matches_from(vec!["test"]);
+        assert_eq!(
+            resolve_color_choice(context_default, &args),
+            ColorChoice::Never
+        )
     }
 }


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

When testing Ion CLI before publishing the 0.12.0 release, I discovered a bug. It turns out that a function I had been using as a guard to prevent panics is actually a no-op when you do a release build, so all my previous testing had missed it. 

Clap's `try_contains_id` relies on `verify_arg` which is gated behind `#[cfg(debug_assertions)]`, so it always returns `Ok(())` in release builds. Commands that don't register `--color`/`--no-color` (e.g., `inspect`) would pass the guard, then `get_flag("color")` would panic because the arg was never configured with `ArgAction::SetTrue`.

The fix uses `try_get_one::<bool>` with pattern matching. For `SetTrue` args, clap stores a default value, so `Ok(Some(&false))` means "registered but not passed" while `Ok(None)` (release) or `Err` (debug) means "never registered." The wildcard arm returns `ColorChoice::Never`, preserving the original semantics.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
