### PR TITLE
build(deps): update `ion-rs` to 1.0.0 and `ion-schema` to 0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "ion-rs"
-version = "1.0.0-rc.12"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc4f9082317e60fd5f7ffbef56f42b37ccce84c8e28c3afae8990c439867186"
+checksum = "8a5bcc8f6c6984869c017fcd205963c411f0c5e89a4cb31577f8914304c8e5c8"
 dependencies = [
  "arrayvec",
  "base64 0.12.3",
@@ -1159,6 +1159,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_with",
+ "sha2 0.9.9",
  "smallvec",
  "thiserror 1.0.69",
  "visibility",
@@ -1167,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "ion-schema"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c9f969910a7cd961148e05dff15316242dc14fc35c096362b37e1bb61451a8"
+checksum = "feb186aa207207c87eccbc9bd80c2225f3753a3c0914176cb7c47c0d50813628"
 dependencies = [
  "half",
  "ion-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ flate2 = "1.0"
 infer = "0.15.0"
 # ion-rs version must be pinned because we are using experimental features
 # See https://github.com/amazon-ion/ion-cli/issues/155
-ion-rs = { version = "1.0.0-rc.12", features = ["experimental", "experimental-ion-hash", "experimental-tooling-apis"] }
-ion-schema = { version = "0.16.0" }
+ion-rs = { version = "=1.0.0", features = ["experimental", "experimental-ion-hash", "experimental-tooling-apis"] }
+ion-schema = { version = "0.16.1" }
 tempfile = "3.2.0"
 lowcharts = "0.5.8"
 serde = { version = "1.0.163", features = ["derive"] }

--- a/src/bin/ion/commands/jq.rs
+++ b/src/bin/ion/commands/jq.rs
@@ -141,8 +141,10 @@ fn filter_and_print(
 /// Wraps an `Element` so we can:
 ///  1. Define implementations of common traits like `Ord` and `Eq` without `Element` itself needing to.
 ///  2. Keep all logic related to `jq` behavior in one place.
-#[derive(Clone, Eq, Debug)]
+#[derive(Clone, Debug)]
 struct JaqElement(Element);
+
+impl Eq for JaqElement {}
 //TODO: move to sibling module so that people can't construct this and have to go through 'from'
 // this will allow consistent construction/transformation rules e.g. field deduplication
 
@@ -212,8 +214,7 @@ impl FromIterator<Self> for JaqElement {
 
 impl PartialEq<Self> for JaqElement {
     fn eq(&self, other: &Self) -> bool {
-        // TODO: Should this use IonData::eq instead?
-        self.0.eq(&other.0)
+        IonData::from(&self.0).eq(&IonData::from(&other.0))
     }
 }
 
@@ -295,7 +296,7 @@ impl Add for JaqElement {
             (Struct(a), Struct(b)) => a.clone_builder().with_fields(b.fields()).build().into(),
 
             // Number types, only lossless operations
-            (Int(a), Int(b)) => (a + b).into(),
+            (Int(a), Int(b)) => a.add(b).into(),
             (Float(a), Float(b)) => a.add(b).into(),
             (Decimal(a), Decimal(b)) => a.add(b).into(),
             (Decimal(a), Int(b)) | (Int(b), Decimal(a)) => a.add(b).into(),
@@ -337,7 +338,7 @@ impl Sub for JaqElement {
             (SExp(a), SExp(b)) => ion_rs::SExp::from_iter(remove_elements(a, &b)).into(),
 
             // Number types, only lossless operations
-            (Int(a), Int(b)) => (a + -b).into(), //TODO: use bare - with ion-rs > rc.11
+            (Int(a), Int(b)) => a.add(b.neg()).into(),
             (Float(a), Float(b)) => a.sub(b).into(),
             (Decimal(a), Decimal(b)) => DecimalMath::sub(a, b).into(),
             (Decimal(a), Int(b)) => DecimalMath::sub(a, b).into(),
@@ -490,7 +491,7 @@ impl Neg for JaqElement {
 
         let elt: Element = match val {
             // Only number types can be negated
-            Int(a) => (-a).into(),
+            Int(a) => a.neg().into(),
             Float(a) => (-a).into(),
             Decimal(a) => (-a.into_big_decimal()).into_decimal().into(),
 
@@ -672,7 +673,7 @@ impl jaq_std::ValT for JaqElement {
 pub(crate) mod ion_math {
     use bigdecimal::num_bigint::BigInt;
     use bigdecimal::{BigDecimal, ToPrimitive};
-    use ion_rs::decimal::coefficient::Sign;
+    use ion_rs::decimal::Sign;
     use ion_rs::{Decimal, Int, Value};
 
     /// We can't provide math traits for Decimal directly, so we have a helper trait

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -5,9 +5,15 @@ use anyhow::Result;
 use anyhow::{bail, Context};
 use clap::builder::ValueParser;
 use clap::{crate_authors, crate_version, Arg, ArgAction, ArgMatches, Command as ClapCommand};
-use ion_rs::Format::Binary;
-use ion_rs::{Format, IonEncoding, TextFormat};
+use ion_rs::{IonEncoding, TextFormat};
 use std::fs::File;
+
+/// Local replacement for the `Format` enum that was removed from ion-rs in 1.0.0.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum Format {
+    Text(TextFormat),
+    Binary,
+}
 use std::io::IsTerminal;
 use std::io::Write;
 use termcolor::{ColorChoice, StandardStream, StandardStreamLock};
@@ -278,7 +284,7 @@ impl CommandIo<'_> {
             (unrecognized, _) => bail!("unrecognized Ion version '{unrecognized}'"),
         };
 
-        let color = if format == Binary {
+        let color = if format == Format::Binary {
             ColorChoice::Never
         } else {
             let default_use_color = std::io::stdout().is_terminal();

--- a/src/bin/ion/output.rs
+++ b/src/bin/ion/output.rs
@@ -1,6 +1,7 @@
+use crate::commands::Format;
 use crate::file_writer::FileWriter;
 use anyhow::bail;
-use ion_rs::{v1_0, v1_1, Format, IonEncoding, Writer};
+use ion_rs::{v1_0, v1_1, IonEncoding, Writer};
 use ion_rs::{IonResult, WriteAsIon};
 use std::io;
 use std::io::Write;

--- a/src/bin/ion/transcribe.rs
+++ b/src/bin/ion/transcribe.rs
@@ -1,3 +1,4 @@
+use crate::commands::Format;
 use anyhow::{bail, Result};
 use ion_rs::*;
 use std::io::Write;


### PR DESCRIPTION
### Issue #, if available:

None.

### Description of changes:

Updating to stable version of ion-rs.

- `Format` enum removed from ion-rs; defined locally in ion-cli
- `Int` arithmetic operators removed; use `.add()`/`.neg()` methods
- `Element` no longer implements `Eq`; use `IonData` for equivalence in `JaqElement` PartialEq to be consistent with Ord
- `decimal::coefficient::Sign` moved to `decimal::Sign`
- Explicit version-pinning using `=` for `ion-rs` so that it doesn't break if there's a new version that changes some of the experimental features.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
